### PR TITLE
Allow Centrallix C tests to be skipped over

### DIFF
--- a/centrallix/tests/README
+++ b/centrallix/tests/README
@@ -82,8 +82,10 @@ NN is the subtest number, starting with 00 or 01, and {category} is a category
 name for the group of tests.
 
 The file should implement a function `long long test(**char name)` that 
-returns 0 if it is successful; if it is not, it should either abort using
-something like assert() or return 1. 
+returns 0 if it is successful. If it is not, it should either abort using
+something like assert() or return a negative value. If the test is skipped
+(for instance, an integration test using the Sybase objectsystem driver that
+automatically skips when Sybase isn't enabled), return 1.
 
 This function should also set the name parameter to the name of the test,
 for instance:

--- a/centrallix/tests/t_driver.c
+++ b/centrallix/tests/t_driver.c
@@ -118,6 +118,8 @@ start(void* v)
 
     if (rval < 0)
         print_result("FAIL", false);
+    else if (rval == 1)
+        print_result("Skipped", true);
     else
         print_result("Pass", true);
 


### PR DESCRIPTION
For instance, say hypothetically that you're writing a test that uses the Sybase objectsystem driver, and should be skipped over if Sybase isn't enabled. The test could look something like this:

```
#include "config.h"
long long test(char** name)
{
    *name = "sybase driver test";

    #ifdef USE_SYBASE
    assert(sybaseThing());
    return 0;
    #else
    return 1;
    #endif
}
```

When USE_SYBASE is defined, the test driver will report that "sybase driver test" passes (if it actually passed, of course). When USE_SYBASE is not defined, the test driver will report that "sybase driver test" was skipped.