### PR TITLE
Http xml memory fix

### DIFF
--- a/centrallix/expression/exp_functions.c
+++ b/centrallix/expression/exp_functions.c
@@ -2883,6 +2883,7 @@ int exp_fn_hash(pExpression tree, pParamObjects objlist, pExpression i0, pExpres
 	    SHA512((unsigned char*)i1->String, strlen(i1->String), hashvalue);
 	    hashlen = 64;
 	    }
+	if (tree->Alloc && tree->String) nmSysFree(tree->String);
 	tree->String = nmSysMalloc(hashlen * 2 + 1);
 	if (!tree->String)
 	    {

--- a/centrallix/expression/exp_functions.c
+++ b/centrallix/expression/exp_functions.c
@@ -2885,6 +2885,7 @@ int exp_fn_hash(pExpression tree, pParamObjects objlist, pExpression i0, pExpres
 	    }
 	if (tree->Alloc && tree->String) nmSysFree(tree->String);
 	tree->String = nmSysMalloc(hashlen * 2 + 1);
+	tree->Alloc = 1;
 	if (!tree->String)
 	    {
 	    mssError(1, "EXP", "hash(): out of memory");

--- a/centrallix/osdrivers/objdrv_http.c
+++ b/centrallix/osdrivers/objdrv_http.c
@@ -534,6 +534,11 @@ http_internal_Cleanup(pHttpData inf)
 	    if (inf->Annotation)
 		nmSysFree(inf->Annotation);
 
+	    /** free SSL context, if needed**/
+	    if(inf->SSL_ctx)
+		SSL_CTX_free(inf->SSL_ctx);
+	    inf->SSL_ctx = NULL;
+
 	    nmFree(inf,sizeof(HttpData));
 	    }
 

--- a/centrallix/osdrivers/objdrv_mysql.c
+++ b/centrallix/osdrivers/objdrv_mysql.c
@@ -3027,10 +3027,13 @@ mysdSetAttrValue(void* inf_v, char* attrname, int datatype, pObjData val, pObjTr
                     {
 		    if (datatype == DATA_T_STRING && type == DATA_T_DATETIME)
 			{
-			/** Promote string to date time **/
-			objDataToDateTime(DATA_T_STRING, val->String, &dt, NULL);
-			od.DateTime = &dt;
-			val = &od;
+			if(val) /** make sure val can be a NULL and still handle as datetime **/
+			    {
+			    /** Promote string to date time **/
+			    objDataToDateTime(DATA_T_STRING, val->String, &dt, NULL);
+			    od.DateTime = &dt;
+			    val = &od;
+			    }
 			datatype = DATA_T_DATETIME;
 			}
                     if (*oxt)

--- a/centrallix/osdrivers/objdrv_xml.c
+++ b/centrallix/osdrivers/objdrv_xml.c
@@ -7,6 +7,7 @@
 #include "cxlib/mtask.h"
 #include "cxlib/xarray.h"
 #include "cxlib/xhash.h"
+#include "cxlib/xhashqueue.h" 
 #include "stparse.h"
 #include "st_node.h"
 #include "cxlib/mtsession.h"


### PR DESCRIPTION
I fixed the major memory leak found in the HTTP driver, and also a minor memory leak found in the expression logic. 
I also included changes the XML driver converting the cache  from a hash-map to a hash-queue. Although this had far less effect on the memory usage than the HTTP driver's memory leak, I did notice that the memory usage now does not grow noticeably, whereas with just the leak fix it would still climb slowly. 