### PR TITLE
Reduce Warnings

### DIFF
--- a/centrallix-lib/src/mtask.c
+++ b/centrallix-lib/src/mtask.c
@@ -694,7 +694,10 @@ int
 r_mtRun_PokeStack()
     {
     char buf[MT_MAX_STACK - MT_TASKSEP*2];
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
     buf[0] = buf[0];
+#pragma GCC diagnostic pop
     return 0;
     }
 
@@ -705,9 +708,15 @@ r_mtRun_Spacer()
      ** it needs to be in order for MTASK to work.  DO NOT OPTIMIZE
      ** THIS MODULE!!!!  The bogus assignment is added to keep gcc -Wall
      ** happy (and silent)....
+     ** 
+     ** Edit (Israel): It wasn't very happy, so I added #pragma gcc directives
+     ** to silence this warning when compiling.
      **/
     char buf[MT_TASKSEP];
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
     buf[MT_TASKSEP-1] = buf[MT_TASKSEP-1];
+#pragma GCC diagnostic pop
 
     /*mprotect((char*)((int)(buf-MT_MAX_STACK+MT_TASKSEP*2+4095) & ~4095), MT_TASKSEP/2, PROT_NONE);*/
     MTASK.CurrentThread->Stack = (unsigned char*)buf;
@@ -730,9 +739,15 @@ r_mtRunStartFn()
      ** it needs to be in order for MTASK to work.  DO NOT OPTIMIZE
      ** THIS MODULE!!!!  The bogus assignment is added to keep gcc -Wall
      ** happy.
+     ** 
+     ** Edit (Israel): It wasn't very happy, so I added #pragma gcc directives
+     ** to silence this warning when compiling.
      **/
     char buf[MT_MAX_STACK];
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
     buf[MT_MAX_STACK-1] = buf[MT_MAX_STACK-1];
+#pragma GCC diagnostic pop
 
     /*if (r_newidx < 0) return 0;*/
     if (--r_newidx) r_mtRunStartFn();
@@ -4265,4 +4280,3 @@ syGetSem(pSemaphore sem, int cnt, int flags)
 
     return code;
     }
-

--- a/centrallix-lib/src/qprintf.c
+++ b/centrallix-lib/src/qprintf.c
@@ -675,7 +675,7 @@ qpf_internal_hexdecode(pQPSession s, const char* src, size_t src_size, char** ds
     char* cursor;
     int ix;
     int req_size;
-    char* orig_src = src;
+    const char* orig_src = src;
 
 	/** Required size **/
 	if (src_size%2 == 1)

--- a/centrallix-lib/tests/test_00baseline.c
+++ b/centrallix-lib/tests/test_00baseline.c
@@ -9,7 +9,7 @@ test(char** tname)
     {
     int i;
     int iter;
-    int array[2];
+    int array[2] = {0};
 
 	*tname = "BASELINE - should pass";
 	iter = 1000*1000*300;
@@ -17,4 +17,3 @@ test(char** tname)
 
     return iter;
     }
-

--- a/centrallix-lib/tests/test_02baseline.c
+++ b/centrallix-lib/tests/test_02baseline.c
@@ -8,11 +8,7 @@
 long long
 test(char** tname)
     {
-    int iter;
-
 	*tname = "BASELINE failed, return value - should fail";
-	iter = 1000*1000*1000;
 
     return -1;
     }
-

--- a/centrallix-lib/tests/test_03baseline.c
+++ b/centrallix-lib/tests/test_03baseline.c
@@ -9,7 +9,7 @@ long long
 test(char** tname)
     {
     int iter;
-    int array[2];
+    int array[2] = {0};
 
 	*tname = "BASELINE sigsegv (11) caused - should crash";
 	iter = 1000*1000*1000;
@@ -17,4 +17,3 @@ test(char** tname)
 
     return iter;
     }
-

--- a/centrallix-lib/tests/test_mtlexer_07.c
+++ b/centrallix-lib/tests/test_mtlexer_07.c
@@ -15,7 +15,6 @@ test(char** tname)
     int j;
     int k;
     int t;
-    int n;
     int iter;
     int flags;
     pLxSession lxs;
@@ -63,4 +62,3 @@ test(char** tname)
 
     return iter * n_tokens * n_iter;
     }
-

--- a/centrallix-lib/tests/test_mtlexer_15.c
+++ b/centrallix-lib/tests/test_mtlexer_15.c
@@ -19,7 +19,6 @@ test(char** tname)
     int flagtypes[5] = { MLX_F_CPPCOMM, MLX_F_POUNDCOMM, MLX_F_SEMICOMM, MLX_F_DASHCOMM, MLX_F_CCOMM };
     int n_flagtypes = 5;
     int flags;
-    char* commnames[5] = { "cppcomm", "poundcomm", "semicomm", "dashcomm", "ccomm" };
     pLxSession lxs;
     pFile fd;
 
@@ -54,4 +53,3 @@ test(char** tname)
 
     return iter * 10;
     }
-

--- a/centrallix-lib/tests/test_mtlexer_16.c
+++ b/centrallix-lib/tests/test_mtlexer_16.c
@@ -19,7 +19,6 @@ test(char** tname)
     int flagtypes[5] = { MLX_F_CPPCOMM, MLX_F_POUNDCOMM, MLX_F_SEMICOMM, MLX_F_DASHCOMM, MLX_F_CCOMM };
     int n_flagtypes = 5;
     int flags;
-    char* commnames[5] = { "cppcomm", "poundcomm", "semicomm", "dashcomm", "ccomm" };
     pLxSession lxs;
     pFile fd;
 
@@ -54,4 +53,3 @@ test(char** tname)
 
     return iter * 10;
     }
-

--- a/centrallix-lib/tests/test_qprintf_00.c
+++ b/centrallix-lib/tests/test_qprintf_00.c
@@ -26,11 +26,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    snprintf(buf+4, 36, "this is a string non-overflow test.");
-	    snprintf(buf+4, 36, "this is a string non-overflow test.");
-	    snprintf(buf+4, 36, "this is a string non-overflow test.");
-	    snprintf(buf+4, 36, "this is a string non-overflow test.");
-	    assert(!strcmp(buf+4,"this is a string non-overflow test."));
+	    snprintf((char*)buf+4, 36, "this is a string non-overflow test.");
+	    snprintf((char*)buf+4, 36, "this is a string non-overflow test.");
+	    snprintf((char*)buf+4, 36, "this is a string non-overflow test.");
+	    snprintf((char*)buf+4, 36, "this is a string non-overflow test.");
+	    assert(!strcmp((char*)buf+4,"this is a string non-overflow test."));
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -44,4 +44,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_01.c
+++ b/centrallix-lib/tests/test_qprintf_01.c
@@ -26,11 +26,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "this is a string non-overflow test.");
-	    qpfPrintf(NULL, buf+4, 36, "this is a string non-overflow test.");
-	    qpfPrintf(NULL, buf+4, 36, "this is a string non-overflow test.");
-	    qpfPrintf(NULL, buf+4, 36, "this is a string non-overflow test.");
-	    assert(!strcmp(buf+4,"this is a string non-overflow test."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "this is a string non-overflow test.");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "this is a string non-overflow test.");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "this is a string non-overflow test.");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "this is a string non-overflow test.");
+	    assert(!strcmp((char*)buf+4,"this is a string non-overflow test."));
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -44,4 +44,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_02.c
+++ b/centrallix-lib/tests/test_qprintf_02.c
@@ -26,11 +26,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "this is a string non-overflow test.... NOT!");
-	    qpfPrintf(NULL, buf+4, 36, "this is a string non-overflow test.... NOT!");
-	    qpfPrintf(NULL, buf+4, 36, "this is a string non-overflow test.... NOT!");
-	    qpfPrintf(NULL, buf+4, 36, "this is a string non-overflow test.... NOT!");
-	    assert(!strcmp(buf+4,"this is a string non-overflow test."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "this is a string non-overflow test.... NOT!");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "this is a string non-overflow test.... NOT!");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "this is a string non-overflow test.... NOT!");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "this is a string non-overflow test.... NOT!");
+	    assert(!strcmp((char*)buf+4,"this is a string non-overflow test."));
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -44,4 +44,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_03.c
+++ b/centrallix-lib/tests/test_qprintf_03.c
@@ -26,11 +26,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "this is a string non-overflow test.?");
-	    qpfPrintf(NULL, buf+4, 36, "this is a string non-overflow test.?");
-	    qpfPrintf(NULL, buf+4, 36, "this is a string non-overflow test.?");
-	    qpfPrintf(NULL, buf+4, 36, "this is a string non-overflow test.?");
-	    assert(!strcmp(buf+4,"this is a string non-overflow test."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "this is a string non-overflow test.?");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "this is a string non-overflow test.?");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "this is a string non-overflow test.?");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "this is a string non-overflow test.?");
+	    assert(!strcmp((char*)buf+4,"this is a string non-overflow test."));
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -44,4 +44,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_04.c
+++ b/centrallix-lib/tests/test_qprintf_04.c
@@ -27,11 +27,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "");
-	    qpfPrintf(NULL, buf+4, 36, "");
-	    qpfPrintf(NULL, buf+4, 36, "");
-	    qpfPrintf(NULL, buf+4, 36, "");
-	    assert(!strcmp(buf+4,""));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "");
+	    assert(!strcmp((char*)buf+4,""));
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -46,4 +46,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_05.c
+++ b/centrallix-lib/tests/test_qprintf_05.c
@@ -28,10 +28,10 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 0, "this is a string overflow test.");
-	    qpfPrintf(NULL, buf+4, 0, "this is a string overflow test.");
-	    qpfPrintf(NULL, buf+4, 0, "this is a string overflow test.");
-	    qpfPrintf(NULL, buf+4, 0, "this is a string overflow test.");
+	    qpfPrintf(NULL, (char*)buf+4, 0, "this is a string overflow test.");
+	    qpfPrintf(NULL, (char*)buf+4, 0, "this is a string overflow test.");
+	    qpfPrintf(NULL, (char*)buf+4, 0, "this is a string overflow test.");
+	    qpfPrintf(NULL, (char*)buf+4, 0, "this is a string overflow test.");
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -47,4 +47,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_06.c
+++ b/centrallix-lib/tests/test_qprintf_06.c
@@ -28,11 +28,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 1, "this is a string overflow test.");
-	    qpfPrintf(NULL, buf+4, 1, "this is a string overflow test.");
-	    qpfPrintf(NULL, buf+4, 1, "this is a string overflow test.");
-	    qpfPrintf(NULL, buf+4, 1, "this is a string overflow test.");
-	    assert(!strcmp(buf+4, ""));
+	    qpfPrintf(NULL, (char*)buf+4, 1, "this is a string overflow test.");
+	    qpfPrintf(NULL, (char*)buf+4, 1, "this is a string overflow test.");
+	    qpfPrintf(NULL, (char*)buf+4, 1, "this is a string overflow test.");
+	    qpfPrintf(NULL, (char*)buf+4, 1, "this is a string overflow test.");
+	    assert(!strcmp((char*)buf+4, ""));
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -48,4 +48,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_07.c
+++ b/centrallix-lib/tests/test_qprintf_07.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "The word %STR is our data.", "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "The word %STR is our data.", "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "The word %STR is our data.", "STRING");
-	    rval = qpfPrintf(NULL, buf+4, 36, "The word %STR is our data.", "STRING");
-	    assert(!strcmp(buf+4, "The word STRING is our data."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The word %STR is our data.", "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The word %STR is our data.", "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The word %STR is our data.", "STRING");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "The word %STR is our data.", "STRING");
+	    assert(!strcmp((char*)buf+4, "The word STRING is our data."));
 	    assert(rval == 28);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_08.c
+++ b/centrallix-lib/tests/test_qprintf_08.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "This is our data: %STR", "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "This is our data: %STR", "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "This is our data: %STR", "STRING");
-	    rval = qpfPrintf(NULL, buf+4, 36, "This is our data: %STR", "STRING");
-	    assert(!strcmp(buf+4, "This is our data: STRING"));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "This is our data: %STR", "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "This is our data: %STR", "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "This is our data: %STR", "STRING");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "This is our data: %STR", "STRING");
+	    assert(!strcmp((char*)buf+4, "This is our data: STRING"));
 	    assert(rval == 24);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_09.c
+++ b/centrallix-lib/tests/test_qprintf_09.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "%STR is our data today.", "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "%STR is our data today.", "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "%STR is our data today.", "STRING");
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR is our data today.", "STRING");
-	    assert(!strcmp(buf+4, "STRING is our data today."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "%STR is our data today.", "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "%STR is our data today.", "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "%STR is our data today.", "STRING");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR is our data today.", "STRING");
+	    assert(!strcmp((char*)buf+4, "STRING is our data today."));
 	    assert(rval == 25);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_10.c
+++ b/centrallix-lib/tests/test_qprintf_10.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    snprintf(buf+4, 36, "The word %s is our data.", "STRING");
-	    snprintf(buf+4, 36, "The word %s is our data.", "STRING");
-	    snprintf(buf+4, 36, "The word %s is our data.", "STRING");
-	    rval = snprintf(buf+4, 36, "The word %s is our data.", "STRING");
-	    assert(!strcmp(buf+4,"The word STRING is our data."));
+	    snprintf((char*)buf+4, 36, "The word %s is our data.", "STRING");
+	    snprintf((char*)buf+4, 36, "The word %s is our data.", "STRING");
+	    snprintf((char*)buf+4, 36, "The word %s is our data.", "STRING");
+	    rval = snprintf((char*)buf+4, 36, "The word %s is our data.", "STRING");
+	    assert(!strcmp((char*)buf+4,"The word STRING is our data."));
 	    assert(rval == 28);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_11.c
+++ b/centrallix-lib/tests/test_qprintf_11.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "The word %STR is our data... this is an overflow", "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "The word %STR is our data... this is an overflow", "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "The word %STR is our data... this is an overflow", "STRING");
-	    rval = qpfPrintf(NULL, buf+4, 36, "The word %STR is our data... this is an overflow", "STRING");
-	    assert(!strcmp(buf+4, "The word STRING is our data... this"));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The word %STR is our data... this is an overflow", "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The word %STR is our data... this is an overflow", "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The word %STR is our data... this is an overflow", "STRING");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "The word %STR is our data... this is an overflow", "STRING");
+	    assert(!strcmp((char*)buf+4, "The word STRING is our data... this"));
 	    assert(rval == 50);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_12.c
+++ b/centrallix-lib/tests/test_qprintf_12.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "The overflow this is data word %STR is our......", "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "The overflow this is data word %STR is our......", "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "The overflow this is data word %STR is our......", "STRING");
-	    rval = qpfPrintf(NULL, buf+4, 36, "The overflow this is data word %STR is our......", "STRING");
-	    assert(!strcmp(buf+4, "The overflow this is data word STRI"));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The overflow this is data word %STR is our......", "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The overflow this is data word %STR is our......", "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The overflow this is data word %STR is our......", "STRING");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "The overflow this is data word %STR is our......", "STRING");
+	    assert(!strcmp((char*)buf+4, "The overflow this is data word STRI"));
 	    assert(rval == 50);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_13.c
+++ b/centrallix-lib/tests/test_qprintf_13.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "The overflow this is...... data word %STR is our", "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "The overflow this is...... data word %STR is our", "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "The overflow this is...... data word %STR is our", "STRING");
-	    rval = qpfPrintf(NULL, buf+4, 36, "The overflow this is...... data word %STR is our", "STRING");
-	    assert(!strcmp(buf+4, "The overflow this is...... data wor"));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The overflow this is...... data word %STR is our", "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The overflow this is...... data word %STR is our", "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The overflow this is...... data word %STR is our", "STRING");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "The overflow this is...... data word %STR is our", "STRING");
+	    assert(!strcmp((char*)buf+4, "The overflow this is...... data wor"));
 	    assert(rval == 50);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_14.c
+++ b/centrallix-lib/tests/test_qprintf_14.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the integer: %INT...", 12345);
-	    qpfPrintf(NULL, buf+4, 36, "Here is the integer: %INT...", 12345);
-	    qpfPrintf(NULL, buf+4, 36, "Here is the integer: %INT...", 12345);
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the integer: %INT...", 12345);
-	    assert(!strcmp(buf+4, "Here is the integer: 12345..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the integer: %INT...", 12345);
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the integer: %INT...", 12345);
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the integer: %INT...", 12345);
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the integer: %INT...", 12345);
+	    assert(!strcmp((char*)buf+4, "Here is the integer: 12345..."));
 	    assert(rval == 29);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_15.c
+++ b/centrallix-lib/tests/test_qprintf_15.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the integer: %POS...", 12345);
-	    qpfPrintf(NULL, buf+4, 36, "Here is the integer: %POS...", 12345);
-	    qpfPrintf(NULL, buf+4, 36, "Here is the integer: %POS...", 12345);
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the integer: %POS...", 12345);
-	    assert(!strcmp(buf+4, "Here is the integer: 12345..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the integer: %POS...", 12345);
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the integer: %POS...", 12345);
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the integer: %POS...", 12345);
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the integer: %POS...", 12345);
+	    assert(!strcmp((char*)buf+4, "Here is the integer: 12345..."));
 	    assert(rval == 29);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_16.c
+++ b/centrallix-lib/tests/test_qprintf_16.c
@@ -26,11 +26,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the integer: %POS...", -12345);
-	    qpfPrintf(NULL, buf+4, 36, "Here is the integer: %POS...", -12345);
-	    qpfPrintf(NULL, buf+4, 36, "Here is the integer: %POS...", -12345);
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the integer: %POS...", -12345);
-	    assert(strlen(buf+4) <= 30);
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the integer: %POS...", -12345);
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the integer: %POS...", -12345);
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the integer: %POS...", -12345);
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the integer: %POS...", -12345);
+	    assert(strlen((char*)buf+4) <= 30);
 	    assert(rval == -EINVAL);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -44,4 +44,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_17.c
+++ b/centrallix-lib/tests/test_qprintf_17.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the string: %6STR...", "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the string: %6STR...", "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the string: %6STR...", "STRING");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the string: %6STR...", "STRING");
-	    assert(!strcmp(buf+4, "Here is the string: STRING..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the string: %6STR...", "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the string: %6STR...", "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the string: %6STR...", "STRING");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the string: %6STR...", "STRING");
+	    assert(!strcmp((char*)buf+4, "Here is the string: STRING..."));
 	    assert(rval == 29);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_18.c
+++ b/centrallix-lib/tests/test_qprintf_18.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the string: %8STR...", "STRINGSTR");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the string: %8STR...", "STRINGSTR");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the string: %8STR...", "STRINGSTR");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the string: %8STR...", "STRINGSTR");
-	    assert(!strcmp(buf+4, "Here is the string: STRINGST..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the string: %8STR...", "STRINGSTR");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the string: %8STR...", "STRINGSTR");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the string: %8STR...", "STRINGSTR");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the string: %8STR...", "STRINGSTR");
+	    assert(!strcmp((char*)buf+4, "Here is the string: STRINGST..."));
 	    assert(rval == 31);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_19.c
+++ b/centrallix-lib/tests/test_qprintf_19.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the string: %*STR...", 8, "STRINGSTR");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the string: %*STR...", 8, "STRINGSTR");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the string: %*STR...", 8, "STRINGSTR");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the string: %*STR...", 8, "STRINGSTR");
-	    assert(!strcmp(buf+4, "Here is the string: STRINGST..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the string: %*STR...", 8, "STRINGSTR");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the string: %*STR...", 8, "STRINGSTR");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the string: %*STR...", 8, "STRINGSTR");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the string: %*STR...", 8, "STRINGSTR");
+	    assert(!strcmp((char*)buf+4, "Here is the string: STRINGST..."));
 	    assert(rval == 31);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_20.c
+++ b/centrallix-lib/tests/test_qprintf_20.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the char: %CHR...", 'c');
-	    qpfPrintf(NULL, buf+4, 36, "Here is the char: %CHR...", 'c');
-	    qpfPrintf(NULL, buf+4, 36, "Here is the char: %CHR...", 'c');
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the char: %CHR...", 'c');
-	    assert(!strcmp(buf+4, "Here is the char: c..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the char: %CHR...", 'c');
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the char: %CHR...", 'c');
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the char: %CHR...", 'c');
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the char: %CHR...", 'c');
+	    assert(!strcmp((char*)buf+4, "Here is the char: c..."));
 	    assert(rval == 22);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_21.c
+++ b/centrallix-lib/tests/test_qprintf_21.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the value: %DBL...", 3.14159);
-	    qpfPrintf(NULL, buf+4, 36, "Here is the value: %DBL...", 3.14159);
-	    qpfPrintf(NULL, buf+4, 36, "Here is the value: %DBL...", 3.14159);
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the value: %DBL...", 3.14159);
-	    assert(!strcmp(buf+4, "Here is the value: 3.141590..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the value: %DBL...", 3.14159);
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the value: %DBL...", 3.14159);
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the value: %DBL...", 3.14159);
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the value: %DBL...", 3.14159);
+	    assert(!strcmp((char*)buf+4, "Here is the value: 3.141590..."));
 	    assert(rval == 30);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_22.c
+++ b/centrallix-lib/tests/test_qprintf_22.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&6LEN...", "STRINGSTR");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&6LEN...", "STRINGSTR");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&6LEN...", "STRINGSTR");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&6LEN...", "STRINGSTR");
-	    assert(!strcmp(buf+4, "Here is the str: STRING..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&6LEN...", "STRINGSTR");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&6LEN...", "STRINGSTR");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&6LEN...", "STRINGSTR");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&6LEN...", "STRINGSTR");
+	    assert(!strcmp((char*)buf+4, "Here is the str: STRING..."));
 	    assert(rval == 26);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_23.c
+++ b/centrallix-lib/tests/test_qprintf_23.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&6LEN...", "STR");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&6LEN...", "STR");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&6LEN...", "STR");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&6LEN...", "STR");
-	    assert(!strcmp(buf+4, "Here is the str: STR..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&6LEN...", "STR");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&6LEN...", "STR");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&6LEN...", "STR");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&6LEN...", "STR");
+	    assert(!strcmp((char*)buf+4, "Here is the str: STR..."));
 	    assert(rval == 23);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_24.c
+++ b/centrallix-lib/tests/test_qprintf_24.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&*LEN...", 8, "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&*LEN...", 8, "STRING");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&*LEN...", 8, "STRING");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&*LEN...", 8, "STRING");
-	    assert(!strcmp(buf+4, "Here is the str: STRING..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&*LEN...", 8, "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&*LEN...", 8, "STRING");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&*LEN...", 8, "STRING");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&*LEN...", 8, "STRING");
+	    assert(!strcmp((char*)buf+4, "Here is the str: STRING..."));
 	    assert(rval == 26);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_25.c
+++ b/centrallix-lib/tests/test_qprintf_25.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&SYM...", "identifier");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&SYM...", "identifier");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&SYM...", "identifier");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&SYM...", "identifier");
-	    assert(!strcmp(buf+4, "Here is the str: identifier..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&SYM...", "identifier");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&SYM...", "identifier");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&SYM...", "identifier");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&SYM...", "identifier");
+	    assert(!strcmp((char*)buf+4, "Here is the str: identifier..."));
 	    assert(rval == 30);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_26.c
+++ b/centrallix-lib/tests/test_qprintf_26.c
@@ -25,10 +25,10 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&SYM...", "00identifier");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&SYM...", "00identifier");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&SYM...", "00identifier");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&SYM...", "00identifier");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&SYM...", "00identifier");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&SYM...", "00identifier");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&SYM...", "00identifier");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&SYM...", "00identifier");
 	    assert(rval < 0);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -42,4 +42,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_27.c
+++ b/centrallix-lib/tests/test_qprintf_27.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ'...", "\"ain't\"");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ'...", "\"ain't\"");
-	    assert(!strcmp(buf+4, "Here is the str: '\\\"ain\\'t\\\"'..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ'...", "\"ain't\"");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ'...", "\"ain't\"");
+	    assert(!strcmp((char*)buf+4, "Here is the str: '\\\"ain\\'t\\\"'..."));
 	    assert(rval == 32);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_28.c
+++ b/centrallix-lib/tests/test_qprintf_28.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str:        '%STR&ESCQ'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str:        '%STR&ESCQ'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str:        '%STR&ESCQ'...", "\"ain't\"");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str:        '%STR&ESCQ'...", "\"ain't\"");
-	    assert(!strcmp(buf+4, "Here is the str:        '\\\"ain\\'t\\\""));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str:        '%STR&ESCQ'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str:        '%STR&ESCQ'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str:        '%STR&ESCQ'...", "\"ain't\"");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str:        '%STR&ESCQ'...", "\"ain't\"");
+	    assert(!strcmp((char*)buf+4, "Here is the str:        '\\\"ain\\'t\\\""));
 	    assert(rval == 39);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_29.c
+++ b/centrallix-lib/tests/test_qprintf_29.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str:         '%STR&ESCQ'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str:         '%STR&ESCQ'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str:         '%STR&ESCQ'...", "\"ain't\"");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str:         '%STR&ESCQ'...", "\"ain't\"");
-	    assert(!strcmp(buf+4, "Here is the str:         '\\\"ain\\'t"));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str:         '%STR&ESCQ'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str:         '%STR&ESCQ'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str:         '%STR&ESCQ'...", "\"ain't\"");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str:         '%STR&ESCQ'...", "\"ain't\"");
+	    assert(!strcmp((char*)buf+4, "Here is the str:         '\\\"ain\\'t"));
 	    assert(rval == 40);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_30.c
+++ b/centrallix-lib/tests/test_qprintf_30.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str:          '%STR&ESCQ'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str:          '%STR&ESCQ'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str:          '%STR&ESCQ'...", "\"ain't\"");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str:          '%STR&ESCQ'...", "\"ain't\"");
-	    assert(!strcmp(buf+4, "Here is the str:          '\\\"ain\\'t"));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str:          '%STR&ESCQ'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str:          '%STR&ESCQ'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str:          '%STR&ESCQ'...", "\"ain't\"");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str:          '%STR&ESCQ'...", "\"ain't\"");
+	    assert(!strcmp((char*)buf+4, "Here is the str:          '\\\"ain\\'t"));
 	    assert(rval == 41);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_31.c
+++ b/centrallix-lib/tests/test_qprintf_31.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&11LEN'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&11LEN'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&11LEN'...", "\"ain't\"");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&11LEN'...", "\"ain't\"");
-	    assert(!strcmp(buf+4, "Here is the str: '\\\"ain\\'t\\\"'..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&11LEN'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&11LEN'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&11LEN'...", "\"ain't\"");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&11LEN'...", "\"ain't\"");
+	    assert(!strcmp((char*)buf+4, "Here is the str: '\\\"ain\\'t\\\"'..."));
 	    assert(rval == 32);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_32.c
+++ b/centrallix-lib/tests/test_qprintf_32.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&10LEN'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&10LEN'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&10LEN'...", "\"ain't\"");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&10LEN'...", "\"ain't\"");
-	    assert(!strcmp(buf+4, "Here is the str: '\\\"ain\\'t\\\"'..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&10LEN'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&10LEN'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&10LEN'...", "\"ain't\"");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&10LEN'...", "\"ain't\"");
+	    assert(!strcmp((char*)buf+4, "Here is the str: '\\\"ain\\'t\\\"'..."));
 	    assert(rval == 32);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_33.c
+++ b/centrallix-lib/tests/test_qprintf_33.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&9LEN'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&9LEN'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&9LEN'...", "\"ain't\"");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&9LEN'...", "\"ain't\"");
-	    assert(!strcmp(buf+4, "Here is the str: '\\\"ain\\'t'..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&9LEN'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&9LEN'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&9LEN'...", "\"ain't\"");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&9LEN'...", "\"ain't\"");
+	    assert(!strcmp((char*)buf+4, "Here is the str: '\\\"ain\\'t'..."));
 	    assert(rval == 30);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_34.c
+++ b/centrallix-lib/tests/test_qprintf_34.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&8LEN'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&8LEN'...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&8LEN'...", "\"ain't\"");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str: '%STR&ESCQ&8LEN'...", "\"ain't\"");
-	    assert(!strcmp(buf+4, "Here is the str: '\\\"ain\\'t'..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&8LEN'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&8LEN'...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&8LEN'...", "\"ain't\"");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: '%STR&ESCQ&8LEN'...", "\"ain't\"");
+	    assert(!strcmp((char*)buf+4, "Here is the str: '\\\"ain\\'t'..."));
 	    assert(rval == 30);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_35.c
+++ b/centrallix-lib/tests/test_qprintf_35.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE'.", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE'.", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE'.", "<b c=\"w\">");
-	    rval = qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE'.", "<b c=\"w\">");
-	    assert(!strcmp(buf+4, "HTML: '&lt;b c=&quot;w&quot;&gt;'."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE'.", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE'.", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE'.", "<b c=\"w\">");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE'.", "<b c=\"w\">");
+	    assert(!strcmp((char*)buf+4, "HTML: '&lt;b c=&quot;w&quot;&gt;'."));
 	    assert(rval == 34);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_36.c
+++ b/centrallix-lib/tests/test_qprintf_36.c
@@ -26,11 +26,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "The HTML: '%STR&HTE'.", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 36, "The HTML: '%STR&HTE'.", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 36, "The HTML: '%STR&HTE'.", "<b c=\"w\">");
-	    rval = qpfPrintf(NULL, buf+4, 36, "The HTML: '%STR&HTE'.", "<b c=\"w\">");
-	    assert(!strcmp(buf+4, "The HTML: '&lt;b c=&quot;w&quot;"));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The HTML: '%STR&HTE'.", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The HTML: '%STR&HTE'.", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "The HTML: '%STR&HTE'.", "<b c=\"w\">");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "The HTML: '%STR&HTE'.", "<b c=\"w\">");
+	    assert(!strcmp((char*)buf+4, "The HTML: '&lt;b c=&quot;w&quot;"));
 	    assert(rval == 38);
 	    assert(buf[39] == '\n');
 	    assert(buf[38] == '\0');
@@ -45,4 +45,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_37.c
+++ b/centrallix-lib/tests/test_qprintf_37.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&26LEN'.", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&26LEN'.", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&26LEN'.", "<b c=\"w\">");
-	    rval = qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&26LEN'.", "<b c=\"w\">");
-	    assert(!strcmp(buf+4, "HTML: '&lt;b c=&quot;w&quot;&gt;'."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&26LEN'.", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&26LEN'.", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&26LEN'.", "<b c=\"w\">");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&26LEN'.", "<b c=\"w\">");
+	    assert(!strcmp((char*)buf+4, "HTML: '&lt;b c=&quot;w&quot;&gt;'."));
 	    assert(rval == 34);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_38.c
+++ b/centrallix-lib/tests/test_qprintf_38.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&25LEN'.", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&25LEN'.", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&25LEN'.", "<b c=\"w\">");
-	    rval = qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&25LEN'.", "<b c=\"w\">");
-	    assert(!strcmp(buf+4, "HTML: '&lt;b c=&quot;w&quot;&gt;'."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&25LEN'.", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&25LEN'.", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&25LEN'.", "<b c=\"w\">");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&25LEN'.", "<b c=\"w\">");
+	    assert(!strcmp((char*)buf+4, "HTML: '&lt;b c=&quot;w&quot;&gt;'."));
 	    assert(rval == 34);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_39.c
+++ b/centrallix-lib/tests/test_qprintf_39.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&24LEN'.", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&24LEN'.", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&24LEN'.", "<b c=\"w\">");
-	    rval = qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&24LEN'.", "<b c=\"w\">");
-	    assert(!strcmp(buf+4, "HTML: '&lt;b c=&quot;w&quot;'."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&24LEN'.", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&24LEN'.", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&24LEN'.", "<b c=\"w\">");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&24LEN'.", "<b c=\"w\">");
+	    assert(!strcmp((char*)buf+4, "HTML: '&lt;b c=&quot;w&quot;'."));
 	    assert(rval == 30);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_40.c
+++ b/centrallix-lib/tests/test_qprintf_40.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&23LEN'.", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&23LEN'.", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&23LEN'.", "<b c=\"w\">");
-	    rval = qpfPrintf(NULL, buf+4, 36, "HTML: '%STR&HTE&23LEN'.", "<b c=\"w\">");
-	    assert(!strcmp(buf+4, "HTML: '&lt;b c=&quot;w&quot;'."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&23LEN'.", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&23LEN'.", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&23LEN'.", "<b c=\"w\">");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "HTML: '%STR&HTE&23LEN'.", "<b c=\"w\">");
+	    assert(!strcmp((char*)buf+4, "HTML: '&lt;b c=&quot;w&quot;'."));
 	    assert(rval == 30);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_41.c
+++ b/centrallix-lib/tests/test_qprintf_41.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Encode: '%STR&HEX'.", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 36, "Encode: '%STR&HEX'.", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 36, "Encode: '%STR&HEX'.", "<b c=\"w\">");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Encode: '%STR&HEX'.", "<b c=\"w\">");
-	    assert(!strcmp(buf+4, "Encode: '3c6220633d2277223e'."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Encode: '%STR&HEX'.", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Encode: '%STR&HEX'.", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Encode: '%STR&HEX'.", "<b c=\"w\">");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Encode: '%STR&HEX'.", "<b c=\"w\">");
+	    assert(!strcmp((char*)buf+4, "Encode: '3c6220633d2277223e'."));
 	    assert(rval == 29);
 	    assert(buf[36] == '\n');
 	    assert(buf[35] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_42.c
+++ b/centrallix-lib/tests/test_qprintf_42.c
@@ -27,11 +27,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 26, "Encode: %STR&HEX", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 26, "Encode: %STR&HEX", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 26, "Encode: %STR&HEX", "<b c=\"w\">");
-	    rval = qpfPrintf(NULL, buf+4, 26, "Encode: %STR&HEX", "<b c=\"w\">");
-	    assert(!strcmp(buf+4, "Encode: 3c6220633d227722"));
+	    qpfPrintf(NULL, (char*)buf+4, 26, "Encode: %STR&HEX", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 26, "Encode: %STR&HEX", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 26, "Encode: %STR&HEX", "<b c=\"w\">");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 26, "Encode: %STR&HEX", "<b c=\"w\">");
+	    assert(!strcmp((char*)buf+4, "Encode: 3c6220633d227722"));
 	    assert(rval == 26);
 	    assert(buf[32] == '\n');
 	    assert(buf[31] == '\0');
@@ -47,4 +47,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_43.c
+++ b/centrallix-lib/tests/test_qprintf_43.c
@@ -27,11 +27,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 25, "Encode: %STR&HEX", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 25, "Encode: %STR&HEX", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 25, "Encode: %STR&HEX", "<b c=\"w\">");
-	    rval = qpfPrintf(NULL, buf+4, 25, "Encode: %STR&HEX", "<b c=\"w\">");
-	    assert(!strcmp(buf+4, "Encode: 3c6220633d227722"));
+	    qpfPrintf(NULL, (char*)buf+4, 25, "Encode: %STR&HEX", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 25, "Encode: %STR&HEX", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 25, "Encode: %STR&HEX", "<b c=\"w\">");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 25, "Encode: %STR&HEX", "<b c=\"w\">");
+	    assert(!strcmp((char*)buf+4, "Encode: 3c6220633d227722"));
 	    assert(rval == 26);
 	    assert(buf[32] == '\n');
 	    assert(buf[31] == '\0');
@@ -47,4 +47,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_44.c
+++ b/centrallix-lib/tests/test_qprintf_44.c
@@ -27,11 +27,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 26, "Enc: %STR&HEX...", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 26, "Enc: %STR&HEX...", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 26, "Enc: %STR&HEX...", "<b c=\"w\">");
-	    rval = qpfPrintf(NULL, buf+4, 26, "Enc: %STR&HEX...", "<b c=\"w\">");
-	    assert(!strcmp(buf+4, "Enc: 3c6220633d2277223e.."));
+	    qpfPrintf(NULL, (char*)buf+4, 26, "Enc: %STR&HEX...", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 26, "Enc: %STR&HEX...", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 26, "Enc: %STR&HEX...", "<b c=\"w\">");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 26, "Enc: %STR&HEX...", "<b c=\"w\">");
+	    assert(!strcmp((char*)buf+4, "Enc: 3c6220633d2277223e.."));
 	    assert(rval == 26);
 	    assert(buf[32] == '\n');
 	    assert(buf[31] == '\0');
@@ -47,4 +47,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_45.c
+++ b/centrallix-lib/tests/test_qprintf_45.c
@@ -27,11 +27,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 27, "Enc: %STR&HEX&18LEN...", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 27, "Enc: %STR&HEX&18LEN...", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 27, "Enc: %STR&HEX&18LEN...", "<b c=\"w\">");
-	    rval = qpfPrintf(NULL, buf+4, 27, "Enc: %STR&HEX&18LEN...", "<b c=\"w\">");
-	    assert(!strcmp(buf+4, "Enc: 3c6220633d2277223e..."));
+	    qpfPrintf(NULL, (char*)buf+4, 27, "Enc: %STR&HEX&18LEN...", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 27, "Enc: %STR&HEX&18LEN...", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 27, "Enc: %STR&HEX&18LEN...", "<b c=\"w\">");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 27, "Enc: %STR&HEX&18LEN...", "<b c=\"w\">");
+	    assert(!strcmp((char*)buf+4, "Enc: 3c6220633d2277223e..."));
 	    assert(rval == 26);
 	    assert(buf[33] == '\n');
 	    assert(buf[32] == '\0');
@@ -47,4 +47,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_46.c
+++ b/centrallix-lib/tests/test_qprintf_46.c
@@ -27,11 +27,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 27, "Enc: %STR&HEX&17LEN...", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 27, "Enc: %STR&HEX&17LEN...", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 27, "Enc: %STR&HEX&17LEN...", "<b c=\"w\">");
-	    rval = qpfPrintf(NULL, buf+4, 27, "Enc: %STR&HEX&17LEN...", "<b c=\"w\">");
-	    assert(!strcmp(buf+4, "Enc: 3c6220633d227722..."));
+	    qpfPrintf(NULL, (char*)buf+4, 27, "Enc: %STR&HEX&17LEN...", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 27, "Enc: %STR&HEX&17LEN...", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 27, "Enc: %STR&HEX&17LEN...", "<b c=\"w\">");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 27, "Enc: %STR&HEX&17LEN...", "<b c=\"w\">");
+	    assert(!strcmp((char*)buf+4, "Enc: 3c6220633d227722..."));
 	    assert(rval == 24);
 	    assert(buf[31] == '\n');
 	    assert(buf[30] == '\0');
@@ -47,4 +47,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_47.c
+++ b/centrallix-lib/tests/test_qprintf_47.c
@@ -27,11 +27,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 27, "Enc: %STR&HEX&16LEN...", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 27, "Enc: %STR&HEX&16LEN...", "<b c=\"w\">");
-	    qpfPrintf(NULL, buf+4, 27, "Enc: %STR&HEX&16LEN...", "<b c=\"w\">");
-	    rval = qpfPrintf(NULL, buf+4, 27, "Enc: %STR&HEX&16LEN...", "<b c=\"w\">");
-	    assert(!strcmp(buf+4, "Enc: 3c6220633d227722..."));
+	    qpfPrintf(NULL, (char*)buf+4, 27, "Enc: %STR&HEX&16LEN...", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 27, "Enc: %STR&HEX&16LEN...", "<b c=\"w\">");
+	    qpfPrintf(NULL, (char*)buf+4, 27, "Enc: %STR&HEX&16LEN...", "<b c=\"w\">");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 27, "Enc: %STR&HEX&16LEN...", "<b c=\"w\">");
+	    assert(!strcmp((char*)buf+4, "Enc: 3c6220633d227722..."));
 	    assert(rval == 24);
 	    assert(buf[31] == '\n');
 	    assert(buf[30] == '\0');
@@ -47,4 +47,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_48.c
+++ b/centrallix-lib/tests/test_qprintf_48.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&QUOT...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&QUOT...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&QUOT...", "\"ain't\"");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&QUOT...", "\"ain't\"");
-	    assert(!strcmp(buf+4, "Here is the str: '\\\"ain\\'t\\\"'..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&QUOT...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&QUOT...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&QUOT...", "\"ain't\"");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&QUOT...", "\"ain't\"");
+	    assert(!strcmp((char*)buf+4, "Here is the str: '\\\"ain\\'t\\\"'..."));
 	    assert(rval == 32);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_49.c
+++ b/centrallix-lib/tests/test_qprintf_49.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&DQUOT...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&DQUOT...", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&DQUOT...", "\"ain't\"");
-	    rval = qpfPrintf(NULL, buf+4, 36, "Here is the str: %STR&DQUOT...", "\"ain't\"");
-	    assert(!strcmp(buf+4, "Here is the str: \"\\\"ain\\'t\\\"\"..."));
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&DQUOT...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&DQUOT...", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&DQUOT...", "\"ain't\"");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the str: %STR&DQUOT...", "\"ain't\"");
+	    assert(!strcmp((char*)buf+4, "Here is the str: \"\\\"ain\\'t\\\"\"..."));
 	    assert(rval == 32);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_50.c
+++ b/centrallix-lib/tests/test_qprintf_50.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 33, "Here is the str...: %STR&QUOT", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 33, "Here is the str...: %STR&QUOT", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 33, "Here is the str...: %STR&QUOT", "\"ain't\"");
-	    rval = qpfPrintf(NULL, buf+4, 33, "Here is the str...: %STR&QUOT", "\"ain't\"");
-	    assert(!strcmp(buf+4, "Here is the str...: '\\\"ain\\'t\\\"'"));
+	    qpfPrintf(NULL, (char*)buf+4, 33, "Here is the str...: %STR&QUOT", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 33, "Here is the str...: %STR&QUOT", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 33, "Here is the str...: %STR&QUOT", "\"ain't\"");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 33, "Here is the str...: %STR&QUOT", "\"ain't\"");
+	    assert(!strcmp((char*)buf+4, "Here is the str...: '\\\"ain\\'t\\\"'"));
 	    assert(rval == 32);
 	    assert(buf[39] == '\n');
 	    assert(buf[38] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_51.c
+++ b/centrallix-lib/tests/test_qprintf_51.c
@@ -27,11 +27,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 32, "Here is the str...: %STR&QUOT", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 32, "Here is the str...: %STR&QUOT", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 32, "Here is the str...: %STR&QUOT", "\"ain't\"");
-	    rval = qpfPrintf(NULL, buf+4, 32, "Here is the str...: %STR&QUOT", "\"ain't\"");
-	    assert(!strcmp(buf+4, "Here is the str...: '\\\"ain\\'t'"));
+	    qpfPrintf(NULL, (char*)buf+4, 32, "Here is the str...: %STR&QUOT", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 32, "Here is the str...: %STR&QUOT", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 32, "Here is the str...: %STR&QUOT", "\"ain't\"");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 32, "Here is the str...: %STR&QUOT", "\"ain't\"");
+	    assert(!strcmp((char*)buf+4, "Here is the str...: '\\\"ain\\'t'"));
 	    assert(rval == 32);
 	    assert(buf[39] == '\n');
 	    assert(buf[38] == '\0');
@@ -47,4 +47,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_52.c
+++ b/centrallix-lib/tests/test_qprintf_52.c
@@ -27,11 +27,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 31, "Here is the str...: %STR&QUOT", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 31, "Here is the str...: %STR&QUOT", "\"ain't\"");
-	    qpfPrintf(NULL, buf+4, 31, "Here is the str...: %STR&QUOT", "\"ain't\"");
-	    rval = qpfPrintf(NULL, buf+4, 31, "Here is the str...: %STR&QUOT", "\"ain't\"");
-	    assert(!strcmp(buf+4, "Here is the str...: '\\\"ain\\'t'"));
+	    qpfPrintf(NULL, (char*)buf+4, 31, "Here is the str...: %STR&QUOT", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 31, "Here is the str...: %STR&QUOT", "\"ain't\"");
+	    qpfPrintf(NULL, (char*)buf+4, 31, "Here is the str...: %STR&QUOT", "\"ain't\"");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "Here is the str...: %STR&QUOT", "\"ain't\"");
+	    assert(!strcmp((char*)buf+4, "Here is the str...: '\\\"ain\\'t'"));
 	    assert(rval == 32);
 	    assert(buf[39] == '\n');
 	    assert(buf[38] == '\0');
@@ -47,4 +47,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_53.c
+++ b/centrallix-lib/tests/test_qprintf_53.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 35, "Here is the str: %STR&HTE&nbsp;", "<tag>");
-	    qpfPrintf(NULL, buf+4, 35, "Here is the str: %STR&HTE&nbsp;", "<tag>");
-	    qpfPrintf(NULL, buf+4, 35, "Here is the str: %STR&HTE&nbsp;", "<tag>");
-	    rval = qpfPrintf(NULL, buf+4, 35, "Here is the str: %STR&HTE&nbsp;", "<tag>");
-	    assert(!strcmp(buf+4, "Here is the str: &lt;tag&gt;&nbsp;"));
+	    qpfPrintf(NULL, (char*)buf+4, 35, "Here is the str: %STR&HTE&nbsp;", "<tag>");
+	    qpfPrintf(NULL, (char*)buf+4, 35, "Here is the str: %STR&HTE&nbsp;", "<tag>");
+	    qpfPrintf(NULL, (char*)buf+4, 35, "Here is the str: %STR&HTE&nbsp;", "<tag>");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 35, "Here is the str: %STR&HTE&nbsp;", "<tag>");
+	    assert(!strcmp((char*)buf+4, "Here is the str: &lt;tag&gt;&nbsp;"));
 	    assert(rval == 34);
 	    assert(buf[41] == '\n');
 	    assert(buf[40] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_54.c
+++ b/centrallix-lib/tests/test_qprintf_54.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 31, "Conditional: yes=%[yes%STR%] no=%[no%STR%]%STR", 1, "!YES!", 0, "!NO!", ".");
-	    qpfPrintf(NULL, buf+4, 31, "Conditional: yes=%[yes%STR%] no=%[no%STR%]%STR", 1, "!YES!", 0, "!NO!", ".");
-	    qpfPrintf(NULL, buf+4, 31, "Conditional: yes=%[yes%STR%] no=%[no%STR%]%STR", 1, "!YES!", 0, "!NO!", ".");
-	    rval = qpfPrintf(NULL, buf+4, 31, "Conditional: yes=%[yes%STR%] no=%[no%STR%]%STR", 1, "!YES!", 0, "!NO!", ".");
-	    assert(!strcmp(buf+4, "Conditional: yes=yes!YES! no=."));
+	    qpfPrintf(NULL, (char*)buf+4, 31, "Conditional: yes=%[yes%STR%] no=%[no%STR%]%STR", 1, "!YES!", 0, "!NO!", ".");
+	    qpfPrintf(NULL, (char*)buf+4, 31, "Conditional: yes=%[yes%STR%] no=%[no%STR%]%STR", 1, "!YES!", 0, "!NO!", ".");
+	    qpfPrintf(NULL, (char*)buf+4, 31, "Conditional: yes=%[yes%STR%] no=%[no%STR%]%STR", 1, "!YES!", 0, "!NO!", ".");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "Conditional: yes=%[yes%STR%] no=%[no%STR%]%STR", 1, "!YES!", 0, "!NO!", ".");
+	    assert(!strcmp((char*)buf+4, "Conditional: yes=yes!YES! no=."));
 	    assert(rval == 30);
 	    assert(buf[38] == '\n');
 	    assert(buf[37] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_55.c
+++ b/centrallix-lib/tests/test_qprintf_55.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 31, "/path/to/%STR&FILE/file", "myfilename.sbd");
-	    qpfPrintf(NULL, buf+4, 31, "/path/to/%STR&FILE/file", "myfilename.sbd");
-	    qpfPrintf(NULL, buf+4, 31, "/path/to/%STR&FILE/file", "myfilename.sbd");
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/to/%STR&FILE/file", "myfilename.sbd");
-	    assert(!strcmp(buf+4, "/path/to/myfilename.sbd/file"));
+	    qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%STR&FILE/file", "myfilename.sbd");
+	    qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%STR&FILE/file", "myfilename.sbd");
+	    qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%STR&FILE/file", "myfilename.sbd");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%STR&FILE/file", "myfilename.sbd");
+	    assert(!strcmp((char*)buf+4, "/path/to/myfilename.sbd/file"));
 	    assert(rval == 28);
 	    assert(buf[35] == '\n');
 	    assert(buf[34] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_56.c
+++ b/centrallix-lib/tests/test_qprintf_56.c
@@ -25,19 +25,19 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/to/%STR&FILE/file", "..");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%STR&FILE/file", "..");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/to/%STR&FILE/file", "../otherdir");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%STR&FILE/file", "../otherdir");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/to/%STR&FILE/file", "dir/..");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%STR&FILE/file", "dir/..");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/to/%STR&FILE/file", "file/subfile");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%STR&FILE/file", "file/subfile");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/to/%STR&FILE/file", "a/../b");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%STR&FILE/file", "a/../b");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/to/%STR&FILE/file", ".");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%STR&FILE/file", ".");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/to/%STR&FILE/file", "");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%STR&FILE/file", "");
 	    assert(rval < 0);
 	    assert(buf[35] == '\n');
 	    assert(buf[34] == '\0');
@@ -51,4 +51,3 @@ test(char** tname)
 
     return iter*7;
     }
-

--- a/centrallix-lib/tests/test_qprintf_57.c
+++ b/centrallix-lib/tests/test_qprintf_57.c
@@ -25,15 +25,15 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/to/%8STR&FILE/file", "file\0ame");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%8STR&FILE/file", "file\0ame");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/to/%8STR&FILE/file", "filenam\0");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%8STR&FILE/file", "filenam\0");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/to/%8STR&FILE/file", "\0ilename");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%8STR&FILE/file", "\0ilename");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/to/%2STR&FILE/file", "...");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%2STR&FILE/file", "...");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/to/%8STR&FILE/file", "filename");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/to/%8STR&FILE/file", "filename");
 	    assert(rval == 22);
 	    assert(buf[35] == '\n');
 	    assert(buf[34] == '\0');
@@ -47,4 +47,3 @@ test(char** tname)
 
     return iter*5;
     }
-

--- a/centrallix-lib/tests/test_qprintf_58.c
+++ b/centrallix-lib/tests/test_qprintf_58.c
@@ -25,11 +25,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH/name", "one/two");
-	    qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH/name", "one/two");
-	    qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH/name", "one/two");
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH/name", "one/two");
-	    assert(strcmp(buf+4,"/path/one/two/name") == 0);
+	    qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH/name", "one/two");
+	    qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH/name", "one/two");
+	    qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH/name", "one/two");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH/name", "one/two");
+	    assert(strcmp((char*)buf+4,"/path/one/two/name") == 0);
 	    assert(rval == 18);
 	    assert(buf[25] == '\n');
 	    assert(buf[24] == '\0');
@@ -43,4 +43,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_qprintf_59.c
+++ b/centrallix-lib/tests/test_qprintf_59.c
@@ -25,19 +25,19 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH/name", "one/../two");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH/name", "one/../two");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH/name", "..");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH/name", "..");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH/name", "../one");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH/name", "../one");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH/name", "one/..");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH/name", "one/..");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH/name", "/..");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH/name", "/..");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH/name", "../");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH/name", "../");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH/name", "/../");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH/name", "/../");
 	    assert(rval < 0);
 	    assert(buf[25] == '\n');
 	    assert(buf[24] == '\0');
@@ -51,4 +51,3 @@ test(char** tname)
 
     return iter*7;
     }
-

--- a/centrallix-lib/tests/test_qprintf_60.c
+++ b/centrallix-lib/tests/test_qprintf_60.c
@@ -25,16 +25,16 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%8STR&PATH/name", "file/..\0");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%8STR&PATH/name", "file/..\0");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%8STR&PATH/name", "one/t/.\0");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%8STR&PATH/name", "one/t/.\0");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%8STR&PATH/name", "one/t/..");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%8STR&PATH/name", "one/t/..");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%8STR&PATH/name", "one/t/...");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%8STR&PATH/name", "one/t/...");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%8STR&PATH/name", "one/two/");
-	    assert(strcmp(buf+4,"/path/one/two//name") == 0);
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%8STR&PATH/name", "one/two/");
+	    assert(strcmp((char*)buf+4,"/path/one/two//name") == 0);
 	    assert(rval == 19);
 	    assert(buf[26] == '\n');
 	    assert(buf[25] == '\0');
@@ -48,4 +48,3 @@ test(char** tname)
 
     return iter*5;
     }
-

--- a/centrallix-lib/tests/test_qprintf_61.c
+++ b/centrallix-lib/tests/test_qprintf_61.c
@@ -25,19 +25,19 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH&8LEN/name", "file/..\0");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH&8LEN/name", "file/..\0");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH&8LEN/name", "files/../");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH&8LEN/name", "files/../");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH&8LEN/name", "one/t/..");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH&8LEN/name", "one/t/..");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH&8LEN/name", "one/t/...");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH&8LEN/name", "one/t/...");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH&8LEN/name", "one/two/");
-	    assert(strcmp(buf+4,"/path/one/two//name") == 0);
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH&8LEN/name", "one/two/");
+	    assert(strcmp((char*)buf+4,"/path/one/two//name") == 0);
 	    assert(rval == 19);
-	    rval = qpfPrintf(NULL, buf+4, 31, "/path/%STR&PATH&8LEN/name", "one/two//");
-	    assert(strcmp(buf+4,"/path/one/two//name") == 0);
+	    rval = qpfPrintf(NULL, (char*)buf+4, 31, "/path/%STR&PATH&8LEN/name", "one/two//");
+	    assert(strcmp((char*)buf+4,"/path/one/two//name") == 0);
 	    assert(rval == 19);
 	    assert(buf[26] == '\n');
 	    assert(buf[25] == '\0');
@@ -51,4 +51,3 @@ test(char** tname)
 
     return iter*6;
     }
-

--- a/centrallix-lib/tests/test_qprintf_62.c
+++ b/centrallix-lib/tests/test_qprintf_62.c
@@ -25,16 +25,16 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DB64", "dGVzdC#BkYXRh");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DB64", "dGVzdC#BkYXRh");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DB64", "#dGVzdCBkYXRh");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DB64", "#dGVzdCBkYXRh");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DB64", "dGVzdCBkYXRh#");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DB64", "dGVzdCBkYXRh#");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DB64", "dGVzdCBkY#XRh");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DB64", "dGVzdCBkY#XRh");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DB64", "dGVzdCBkYXRh");
-	    assert(strcmp(buf+4,"test data") == 0);
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DB64", "dGVzdCBkYXRh");
+	    assert(strcmp((char*)buf+4,"test data") == 0);
 	    assert(rval == 9);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -48,4 +48,3 @@ test(char** tname)
 
     return iter*6;
     }
-

--- a/centrallix-lib/tests/test_qprintf_63.c
+++ b/centrallix-lib/tests/test_qprintf_63.c
@@ -25,9 +25,9 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DB64", "dGVzdCBkYXRh");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DB64", "dGVzdCBkYXRh");
 	    assert(rval == 9);
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DB64", "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DB64", "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg");
 	    assert(rval < 0);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -41,4 +41,3 @@ test(char** tname)
 
     return iter*2;
     }
-

--- a/centrallix-lib/tests/test_qprintf_64.c
+++ b/centrallix-lib/tests/test_qprintf_64.c
@@ -25,9 +25,9 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    rval = qpfPrintf(NULL, (char*)(buf+4), 36, "%STR&B64", "test data");
+	    rval = qpfPrintf(NULL, (char*)((char*)buf+4), 36, "%STR&B64", "test data");
 	    assert(rval == strlen("dGVzdCBkYXRh"));
-	    assert(strcmp(buf+4, "dGVzdCBkYXRh") == 0);
+	    assert(strcmp((char*)buf+4, "dGVzdCBkYXRh") == 0);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -40,4 +40,3 @@ test(char** tname)
 
     return iter;
     }
-

--- a/centrallix-lib/tests/test_qprintf_65.c
+++ b/centrallix-lib/tests/test_qprintf_65.c
@@ -25,9 +25,9 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    rval = qpfPrintf(NULL, (char*)(buf+4), 36, "%STR&B64", "test data");
+	    rval = qpfPrintf(NULL, (char*)((char*)buf+4), 36, "%STR&B64", "test data");
 	    assert(rval == strlen("dGVzdCBkYXRh"));
-	    rval = qpfPrintf(NULL, (char*)(buf+4), 36, "%STR&B64", "the quick brown fox jumps ov");
+	    rval = qpfPrintf(NULL, (char*)((char*)buf+4), 36, "%STR&B64", "the quick brown fox jumps ov");
 	    assert(rval < 0);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -41,4 +41,3 @@ test(char** tname)
 
     return iter*2;
     }
-

--- a/centrallix-lib/tests/test_qprintf_66.c
+++ b/centrallix-lib/tests/test_qprintf_66.c
@@ -30,12 +30,12 @@ test(char** tname)
         //Test value > INT_MAX
         long long testNum = 2200000000ll;
 
-        qpfPrintf(NULL, buf + 4, 36, "Here is the ll: %LL...", testNum);
-        qpfPrintf(NULL, buf+4, 36, "Here is the ll: %LL...", testNum);
-        qpfPrintf(NULL, buf+4, 36, "Here is the ll: %LL...", testNum);
-        rval = qpfPrintf(NULL, buf+4, 36, "Here is the ll: %LL...", testNum);
+        qpfPrintf(NULL, (char*)buf+4, 36, "Here is the ll: %LL...", testNum);
+        qpfPrintf(NULL, (char*)buf+4, 36, "Here is the ll: %LL...", testNum);
+        qpfPrintf(NULL, (char*)buf+4, 36, "Here is the ll: %LL...", testNum);
+        rval = qpfPrintf(NULL, (char*)buf+4, 36, "Here is the ll: %LL...", testNum);
 
-        assert(!strcmp(buf+4, "Here is the ll: 2200000000..."));
+        assert(!strcmp((char*)buf+4, "Here is the ll: 2200000000..."));
         //For the long long case, rval will be set to the return value of snprintf, i.e. length of string
         assert(rval == 29);
         assert(buf[34] == 0xff);

--- a/centrallix-lib/tests/test_qprintf_67.c
+++ b/centrallix-lib/tests/test_qprintf_67.c
@@ -25,21 +25,21 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DHEX", "4142434D4E4F#");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DHEX", "4142434D4E4F#");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DHEX", "414243#4D4E4F");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DHEX", "414243#4D4E4F");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DHEX", "41424#34D4E4F");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DHEX", "41424#34D4E4F");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DHEX", "#4142434D4E4F");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DHEX", "#4142434D4E4F");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DHEX", "4142434D4E4");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DHEX", "4142434D4E4");
 	    assert(rval < 0);
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DHEX", "4142434D4E4F");
-	    assert(strcmp(buf+4,"ABCMNO") == 0);
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DHEX", "4142434D4E4F");
+	    assert(strcmp((char*)buf+4,"ABCMNO") == 0);
 	    assert(rval == 6);
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DHEX", "4142434d4e4f");
-	    assert(strcmp(buf+4,"ABCMNO") == 0);
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DHEX", "4142434d4e4f");
+	    assert(strcmp((char*)buf+4,"ABCMNO") == 0);
 	    assert(rval == 6);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -53,4 +53,3 @@ test(char** tname)
 
     return iter*7;
     }
-

--- a/centrallix-lib/tests/test_qprintf_68.c
+++ b/centrallix-lib/tests/test_qprintf_68.c
@@ -25,9 +25,9 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DHEX", "414243444546");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DHEX", "414243444546");
 	    assert(rval == 6);
-	    rval = qpfPrintf(NULL, buf+4, 36, "%STR&DHEX", "4142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F60616263646566676869");
+	    rval = qpfPrintf(NULL, (char*)buf+4, 36, "%STR&DHEX", "4142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F60616263646566676869");
 	    assert(rval < 0);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -41,4 +41,3 @@ test(char** tname)
 
     return iter*2;
     }
-

--- a/centrallix-lib/tests/test_smmalloc_09.c
+++ b/centrallix-lib/tests/test_smmalloc_09.c
@@ -8,6 +8,7 @@
 #include <sys/types.h>
 #include <sys/ipc.h>
 #include <sys/msg.h>
+#include <sys/wait.h>
 
 long long
 test(char** tname)
@@ -83,4 +84,3 @@ test(char** tname)
 
     return iter;
     }
-

--- a/centrallix-lib/tests/test_strtcpy_00.c
+++ b/centrallix-lib/tests/test_strtcpy_00.c
@@ -26,11 +26,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    strcpy(buf+4, "this is a string non-overflow test.");
-	    strcpy(buf+4, "this is a string non-overflow test.");
-	    strcpy(buf+4, "this is a string non-overflow test.");
-	    strcpy(buf+4, "this is a string non-overflow test.");
-	    assert(!strcmp(buf+4,"this is a string non-overflow test."));
+	    strcpy((char*)buf+4, "this is a string non-overflow test.");
+	    strcpy((char*)buf+4, "this is a string non-overflow test.");
+	    strcpy((char*)buf+4, "this is a string non-overflow test.");
+	    strcpy((char*)buf+4, "this is a string non-overflow test.");
+	    assert(!strcmp((char*)buf+4,"this is a string non-overflow test."));
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -44,4 +44,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_strtcpy_01.c
+++ b/centrallix-lib/tests/test_strtcpy_01.c
@@ -26,15 +26,15 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    memccpy(buf+4, "this is a string non-overflow test.", '\0', 36-1);
-	    (buf+4)[36-1] = '\0';
-	    memccpy(buf+4, "this is a string non-overflow test.", '\0', 36-1);
-	    (buf+4)[36-1] = '\0';
-	    memccpy(buf+4, "this is a string non-overflow test.", '\0', 36-1);
-	    (buf+4)[36-1] = '\0';
-	    memccpy(buf+4, "this is a string non-overflow test.", '\0', 36-1);
-	    (buf+4)[36-1] = '\0';
-	    assert(!strcmp(buf+4,"this is a string non-overflow test."));
+	    memccpy((char*)buf+4, "this is a string non-overflow test.", '\0', 36-1);
+	    ((char*)buf+4)[36-1] = '\0';
+	    memccpy((char*)buf+4, "this is a string non-overflow test.", '\0', 36-1);
+	    ((char*)buf+4)[36-1] = '\0';
+	    memccpy((char*)buf+4, "this is a string non-overflow test.", '\0', 36-1);
+	    ((char*)buf+4)[36-1] = '\0';
+	    memccpy((char*)buf+4, "this is a string non-overflow test.", '\0', 36-1);
+	    ((char*)buf+4)[36-1] = '\0';
+	    assert(!strcmp((char*)buf+4,"this is a string non-overflow test."));
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -48,4 +48,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_strtcpy_02.c
+++ b/centrallix-lib/tests/test_strtcpy_02.c
@@ -26,11 +26,11 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    snprintf(buf+4, 36, "this is a string non-overflow test.");
-	    snprintf(buf+4, 36, "this is a string non-overflow test.");
-	    snprintf(buf+4, 36, "this is a string non-overflow test.");
-	    snprintf(buf+4, 36, "this is a string non-overflow test.");
-	    assert(!strcmp(buf+4,"this is a string non-overflow test."));
+	    snprintf((char*)buf+4, 36, "this is a string non-overflow test.");
+	    snprintf((char*)buf+4, 36, "this is a string non-overflow test.");
+	    snprintf((char*)buf+4, 36, "this is a string non-overflow test.");
+	    snprintf((char*)buf+4, 36, "this is a string non-overflow test.");
+	    assert(!strcmp((char*)buf+4,"this is a string non-overflow test."));
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -44,4 +44,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_strtcpy_03.c
+++ b/centrallix-lib/tests/test_strtcpy_03.c
@@ -26,12 +26,12 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    strtcpy(buf+4, "this is a string non-overflow test.", 36);
-	    strtcpy(buf+4, "this is a string non-overflow test.", 36);
-	    strtcpy(buf+4, "this is a string non-overflow test.", 36);
-	    rval = strtcpy(buf+4, "this is a string non-overflow test.", 36);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.", 36);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.", 36);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.", 36);
+	    rval = strtcpy((char*)buf+4, "this is a string non-overflow test.", 36);
 	    assert(rval == 36);
-	    assert(!strcmp(buf+4,"this is a string non-overflow test."));
+	    assert(!strcmp((char*)buf+4,"this is a string non-overflow test."));
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -45,4 +45,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_strtcpy_04.c
+++ b/centrallix-lib/tests/test_strtcpy_04.c
@@ -26,12 +26,12 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    strtcpy(buf+4, "this is a string non-overflow test.?", 36);
-	    strtcpy(buf+4, "this is a string non-overflow test.?", 36);
-	    strtcpy(buf+4, "this is a string non-overflow test.?", 36);
-	    rval = strtcpy(buf+4, "this is a string non-overflow test.?", 36);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.?", 36);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.?", 36);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.?", 36);
+	    rval = strtcpy((char*)buf+4, "this is a string non-overflow test.?", 36);
 	    assert(rval == -36);
-	    assert(!strcmp(buf+4,"this is a string non-overflow test."));
+	    assert(!strcmp((char*)buf+4,"this is a string non-overflow test."));
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -45,4 +45,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_strtcpy_05.c
+++ b/centrallix-lib/tests/test_strtcpy_05.c
@@ -26,12 +26,12 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    strtcpy(buf+4, "this is a string non-overflow test... NOT!!", 36);
-	    strtcpy(buf+4, "this is a string non-overflow test... NOT!!", 36);
-	    strtcpy(buf+4, "this is a string non-overflow test... NOT!!", 36);
-	    rval = strtcpy(buf+4, "this is a string non-overflow test... NOT!!", 36);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test... NOT!!", 36);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test... NOT!!", 36);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test... NOT!!", 36);
+	    rval = strtcpy((char*)buf+4, "this is a string non-overflow test... NOT!!", 36);
 	    assert(rval == -36);
-	    assert(!strcmp(buf+4,"this is a string non-overflow test."));
+	    assert(!strcmp((char*)buf+4,"this is a string non-overflow test."));
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -45,4 +45,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_strtcpy_06.c
+++ b/centrallix-lib/tests/test_strtcpy_06.c
@@ -28,10 +28,10 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    strtcpy(buf+4, "this is a string non-overflow test.?", 0);
-	    strtcpy(buf+4, "this is a string non-overflow test.?", 0);
-	    strtcpy(buf+4, "this is a string non-overflow test.?", 0);
-	    rval = strtcpy(buf+4, "this is a string non-overflow test.?", 0);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.?", 0);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.?", 0);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.?", 0);
+	    rval = strtcpy((char*)buf+4, "this is a string non-overflow test.?", 0);
 	    assert(rval == 0);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -48,4 +48,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_strtcpy_07.c
+++ b/centrallix-lib/tests/test_strtcpy_07.c
@@ -29,10 +29,10 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    strtcpy(buf+4, "this is a string non-overflow test.?", 1);
-	    strtcpy(buf+4, "this is a string non-overflow test.?", 1);
-	    strtcpy(buf+4, "this is a string non-overflow test.?", 1);
-	    rval = strtcpy(buf+4, "this is a string non-overflow test.?", 1);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.?", 1);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.?", 1);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.?", 1);
+	    rval = strtcpy((char*)buf+4, "this is a string non-overflow test.?", 1);
 	    assert(rval == -1);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -50,4 +50,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_strtcpy_08.c
+++ b/centrallix-lib/tests/test_strtcpy_08.c
@@ -35,10 +35,10 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    strtcpy(buf+4, "this is a string non-overflow test.?", 2);
-	    strtcpy(buf+4, "this is a string non-overflow test.?", 2);
-	    strtcpy(buf+4, "this is a string non-overflow test.?", 2);
-	    rval = strtcpy(buf+4, "this is a string non-overflow test.?", 2);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.?", 2);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.?", 2);
+	    strtcpy((char*)buf+4, "this is a string non-overflow test.?", 2);
+	    rval = strtcpy((char*)buf+4, "this is a string non-overflow test.?", 2);
 	    assert(rval == -2);
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
@@ -56,4 +56,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_strtcpy_09.c
+++ b/centrallix-lib/tests/test_strtcpy_09.c
@@ -27,12 +27,12 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    strtcpy(buf+4, "this is a non-overflow test.", 36);
-	    strtcpy(buf+4, "this is a non-overflow test.", 36);
-	    strtcpy(buf+4, "this is a non-overflow test.", 36);
-	    rval = strtcpy(buf+4, "this is a non-overflow test.", 36);
+	    strtcpy((char*)buf+4, "this is a non-overflow test.", 36);
+	    strtcpy((char*)buf+4, "this is a non-overflow test.", 36);
+	    strtcpy((char*)buf+4, "this is a non-overflow test.", 36);
+	    rval = strtcpy((char*)buf+4, "this is a non-overflow test.", 36);
 	    assert(rval == 29);
-	    assert(!strcmp(buf+4,"this is a non-overflow test."));
+	    assert(!strcmp((char*)buf+4,"this is a non-overflow test."));
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -47,4 +47,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix-lib/tests/test_strtcpy_10.c
+++ b/centrallix-lib/tests/test_strtcpy_10.c
@@ -27,12 +27,12 @@ test(char** tname)
 	    buf[2] = '\0';
 	    buf[1] = 0xff;
 	    buf[0] = '\0';
-	    strtcpy(buf+4, "", 36);
-	    strtcpy(buf+4, "", 36);
-	    strtcpy(buf+4, "", 36);
-	    rval = strtcpy(buf+4, "", 36);
+	    strtcpy((char*)buf+4, "", 36);
+	    strtcpy((char*)buf+4, "", 36);
+	    strtcpy((char*)buf+4, "", 36);
+	    rval = strtcpy((char*)buf+4, "", 36);
 	    assert(rval == 1);
-	    assert(!strcmp(buf+4,""));
+	    assert(!strcmp((char*)buf+4,""));
 	    assert(buf[43] == '\n');
 	    assert(buf[42] == '\0');
 	    assert(buf[41] == 0xff);
@@ -47,4 +47,3 @@ test(char** tname)
 
     return iter*4;
     }
-

--- a/centrallix/cxss/cxss_credentials_mgr.c
+++ b/centrallix/cxss/cxss_credentials_mgr.c
@@ -130,13 +130,13 @@ cxssAddUser(const char *cxss_userid, const char *pb_userkey, size_t pb_userkey_l
 
     free(encrypted_privatekey);
     cxssDestroyKey(privatekey, privatekey_len);
-    cxssShred(pb_userkey, pb_userkey_len);    
+    cxssShred((char*)pb_userkey, pb_userkey_len);    
     return CXSS_MGR_SUCCESS;
 
 error:
     free(encrypted_privatekey);
     cxssDestroyKey(privatekey, privatekey_len);
-    cxssShred(pb_userkey, pb_userkey_len);
+    cxssShred((char*)pb_userkey, pb_userkey_len);
     return CXSS_MGR_INSERT_ERROR;
 }
 
@@ -170,13 +170,13 @@ cxssRetrieveUserPrivateKey(const char *cxss_userid, const char *pb_userkey, size
     *privatekey_len = UserAuth.KeyLength;
     
     cxssFreeUserAuth(&UserAuth);  
-    cxssShred(pb_userkey, pb_userkey_len);
+    cxssShred((char*)pb_userkey, pb_userkey_len);
     return CXSS_MGR_SUCCESS;
 
 error:
     free(*privatekey);
     cxssFreeUserAuth(&UserAuth);
-    cxssShred(pb_userkey, pb_userkey_len);
+    cxssShred((char*)pb_userkey, pb_userkey_len);
     return CXSS_MGR_RETRIEVE_ERROR;
 }
 
@@ -314,16 +314,16 @@ cxssAddResource(const char *cxss_userid, const char *resource_id, const char *au
     free(publickey);
     free(encrypted_username);
     free(encrypted_password);
-    cxssShred(resource_username, username_len);
-    cxssShred(resource_authdata, authdata_len);
+    cxssShred((char*)resource_username, username_len);
+    cxssShred((char*)resource_authdata, authdata_len);
     return CXSS_MGR_SUCCESS;
 
 error:
     free(publickey);
     free(encrypted_username);
     free(encrypted_password);
-    cxssShred(resource_username, username_len);
-    cxssShred(resource_authdata, authdata_len);
+    cxssShred((char*)resource_username, username_len);
+    cxssShred((char*)resource_authdata, authdata_len);
     return CXSS_MGR_INSERT_ERROR;
 }
 
@@ -392,7 +392,7 @@ cxssGetResource(const char *cxss_userid, const char *resource_id, const char *pb
     cxssFreeUserAuth(&UserAuth);
     cxssFreeUserResc(&UserResc);
     cxssDestroyKey(privatekey, privatekey_len);
-    cxssShred(pb_userkey, pb_userkey_len);
+    cxssShred((char*)pb_userkey, pb_userkey_len);
     return CXSS_MGR_SUCCESS;
 
 error:
@@ -401,7 +401,7 @@ error:
     cxssDestroyKey(privatekey, privatekey_len);
     cxssDestroyKey(*resource_username, username_len);
     cxssDestroyKey(*resource_authdata, authdata_len);  
-    cxssShred(pb_userkey, pb_userkey_len);  
+    cxssShred((char*)pb_userkey, pb_userkey_len);  
     return CXSS_MGR_RETRIEVE_ERROR;
 }
 

--- a/centrallix/cxss/cxss_crypto.c
+++ b/centrallix/cxss/cxss_crypto.c
@@ -27,7 +27,7 @@ static bool CSPRNG_Initialized = false;
 void
 cxssCryptoInit(void)
 {
-    char seed[256];
+    unsigned char seed[256];
 
     /* Generate seed and init OpenSSL RNG */
     cxss_internal_GetBytes(seed, 256); 

--- a/centrallix/htmlgen/htdrv_alerter.c
+++ b/centrallix/htmlgen/htdrv_alerter.c
@@ -42,23 +42,11 @@
 /************************************************************************/
 
 
-/** globals **/
-static struct 
-    {
-    int		idcnt;
-    }
-    HTALRT;
-
-
 /*** htalrtRender - generate the HTML code for the alert -- not much..
  ***/
 int
 htalrtRender(pHtSession s, pWgtrNode tree, int z)
     {
-    int id;
-    
-    	/** Get an id for this. **/
-	id = (HTALRT.idcnt++);
 
 	/** Get name **/
 	htrAddScriptInit_va(s,"    alrt_init(wgtrGetNodeRef(ns,\"%STR&SYM\"));\n", wgtrGetName(tree));
@@ -75,8 +63,6 @@ int
 htalrtInitialize()
     {
     pHtDriver drv;
-
-	HTALRT.idcnt = 0;
 
     	/** Allocate the driver **/
 	drv = htrAllocDriver();

--- a/centrallix/htmlgen/htdrv_componentdecl.c
+++ b/centrallix/htmlgen/htdrv_componentdecl.c
@@ -48,14 +48,6 @@
 /************************************************************************/
 
 
-/** globals **/
-static struct 
-    {
-    int		idcnt;
-    }
-    HTCMPD;
-
-
 /** structure defining a param to the component **/
 typedef struct
     {
@@ -79,7 +71,6 @@ htcmpdRender(pHtSession s, pWgtrNode tree, int z)
     char expose_actions_for[64] = "";
     char expose_props_for[64] = "";
     char apply_hints_to[64] = "";
-    int id;
     /*char* nptr;*/
 //    pObject subobj = NULL;
     pWgtrNode sub_tree = NULL;
@@ -101,9 +92,6 @@ htcmpdRender(pHtSession s, pWgtrNode tree, int z)
 	    mssError(1,"HTCMPD","Either Netscape DOM or W3C DOM1 HTML and W3C CSS support required");
 	    return -1;
 	    }
-
-    	/** Get an id for this. **/
-	id = (HTCMPD.idcnt++);
 
 	/** Is this a visual component? **/
 	if ((is_visual = htrGetBoolean(tree, "visual", 1)) < 0)
@@ -423,8 +411,5 @@ htcmpdInitialize()
 	/** Declare support for DHTML user interface class **/
 	htrAddSupport(drv, "dhtml");
 
-	HTCMPD.idcnt = 0;
-
     return 0;
     }
-

--- a/centrallix/htmlgen/htdrv_connector.c
+++ b/centrallix/htmlgen/htdrv_connector.c
@@ -45,14 +45,6 @@
 /************************************************************************/
 
 
-/** globals **/
-static struct 
-    {
-    int		idcnt;
-    }
-    HTCONN;
-
-
 /*** htconnRender - generate the HTML code for the page.
  ***/
 int
@@ -67,7 +59,7 @@ htconnRender(pHtSession s, pWgtrNode tree, int z)
     char target[128];
     char source[128];
     char action[32] = "";
-    int id, i;
+    int i;
     XString xs;
     pExpression code;
     int first;
@@ -79,9 +71,6 @@ htconnRender(pHtSession s, pWgtrNode tree, int z)
 	    mssError(1,"HTCONN","Netscape DOM or W3C DOM1HTML support required");
 	    return -1;
 	    }
-
-    	/** Get an id for this. **/
-	id = (HTCONN.idcnt++);
 
 	/** Inside a component-decl-action? **/
 	if (tree->Parent && wgtrGetPropertyValue(tree->Parent, "outer_type", DATA_T_STRING, POD(&ptr)) == 0 && !strcmp(ptr, "widget/component-decl-action"))
@@ -271,8 +260,6 @@ htconnInitialize()
 	htrRegisterDriver(drv);
 
 	htrAddSupport(drv, "dhtml");
-
-	HTCONN.idcnt = 0;
 
     return 0;
     }

--- a/centrallix/htmlgen/htdrv_execmethod.c
+++ b/centrallix/htmlgen/htdrv_execmethod.c
@@ -44,14 +44,6 @@
 /************************************************************************/
 
 
-/** globals **/
-static struct 
-    {
-    int		idcnt;
-    }
-    HTEX;
-
-
 /*** htexRender - generate the HTML code for the timer nonvisual widget.
  ***/
 int
@@ -59,7 +51,6 @@ htexRender(pHtSession s, pWgtrNode tree, int z)
     {
     char* ptr;
     char name[64];
-    int id;
     char* objname;
     char* methodname = NULL;
     char* methodparam = NULL;
@@ -69,9 +60,6 @@ htexRender(pHtSession s, pWgtrNode tree, int z)
 	    mssError(1,"HTTEX","Netscape DOM support required");
 	    return -1;
 	    }
-
-    	/** Get an id for this. **/
-	id = (HTEX.idcnt++);
 
 	/** Get params. **/
 	if (wgtrGetPropertyValue(tree,"object",DATA_T_STRING,POD(&objname)) != 0) objname="";
@@ -121,8 +109,6 @@ htexInitialize()
 	htrRegisterDriver(drv);
 
 	htrAddSupport(drv, "dhtml");
-
-	HTEX.idcnt = 0;
 
     return 0;
     }

--- a/centrallix/htmlgen/htdrv_form.c
+++ b/centrallix/htmlgen/htdrv_form.c
@@ -44,14 +44,6 @@
 /************************************************************************/
 
 
-/** globals **/
-static struct 
-    {
-    int		idcnt;
-    }
-    HTFORM;
-
-
 /*** htformRender - generate the HTML code for the form 'glue'
  ***/
 int
@@ -66,7 +58,7 @@ htformRender(pHtSession s, pWgtrNode tree, int z)
     char link_prev[64];
     char link_prev_within[64];
     char interlock_with[256];
-    int id, i, t;
+    int i, t;
     int allowquery, allownew, allowmodify, allowview, allownodata, multienter, allowdelete, confirmdelete;
     int confirmdiscard, allowmerge;
     int allowobscure = 0;
@@ -78,9 +70,6 @@ htformRender(pHtSession s, pWgtrNode tree, int z)
     pStringVec sv;
 
 	/** form widget should work on any browser **/
-    
-    	/** Get an id for this. **/
-	id = (HTFORM.idcnt++);
 
 	/** Get params. **/
 	allowquery = htrGetBoolean(tree, "allow_query", 1);
@@ -304,8 +293,6 @@ htformInitialize()
 	htrRegisterDriver(drv);
 
 	htrAddSupport(drv, "dhtml");
-
-	HTFORM.idcnt = 0;
 
     return 0;
     }

--- a/centrallix/htmlgen/htdrv_hints.c
+++ b/centrallix/htmlgen/htdrv_hints.c
@@ -43,25 +43,13 @@
 /************************************************************************/
 
 
-/** globals **/
-static struct 
-    {
-    int		idcnt;
-    }
-    HTHINT;
-
-
 /*** hthintRender - generate the HTML code for the page.
  ***/
 int
 hthintRender(pHtSession s, pWgtrNode tree, int z)
     {
-    int id;
     pObjPresentationHints hints;
     XString xs;
-
-    	/** Get an id for this. **/
-	id = (HTHINT.idcnt++);
 
 	/** Convert the object data into hints data **/
 	hints = wgtrWgtToHints(tree);
@@ -108,8 +96,6 @@ hthintInitialize()
 	htrRegisterDriver(drv);
 
 	htrAddSupport(drv, "dhtml");
-
-	HTHINT.idcnt = 0;
 
     return 0;
     }

--- a/centrallix/htmlgen/htdrv_multiscroll.c
+++ b/centrallix/htmlgen/htdrv_multiscroll.c
@@ -63,7 +63,6 @@ htmsRender(pHtSession s, pWgtrNode tree, int z)
     int x=-1,y=-1,w,h,ch,total_h,top_h,total_h_accum,cy;
     int id;
     int i, cnt;
-    int box_offset;
     int always_visible;
     pWgtrNode childlist[32];
     pWgtrNode child;
@@ -93,12 +92,6 @@ htmsRender(pHtSession s, pWgtrNode tree, int z)
 
 	/** Background color/image? **/
 	htrGetBackground(tree,NULL,!s->Capabilities.Dom0NS,main_bg,sizeof(main_bg));
-
-	/** figure out box offset fudge factor... stupid box model... **/
-	if (s->Capabilities.CSSBox)
-	    box_offset = 1;
-	else
-	    box_offset = 0;
 
 	/** Get name **/
 	if (wgtrGetPropertyValue(tree,"name",DATA_T_STRING,POD(&ptr)) != 0) return -1;

--- a/centrallix/htmlgen/htdrv_parameter.c
+++ b/centrallix/htmlgen/htdrv_parameter.c
@@ -45,14 +45,6 @@
 /************************************************************************/
 
 
-/** globals **/
-static struct 
-    {
-    int		idcnt;
-    }
-    HTPARAM;
-
-
 /*** htparamRender - generate the HTML code for the page.
  ***/
 int
@@ -63,7 +55,6 @@ htparamRender(pHtSession s, pWgtrNode tree, int z)
     char paramname[64];
     char type[32];
     char findcontainer[64];
-    int id;
     int i;
     XString xs;
     pObjPresentationHints hints;
@@ -75,9 +66,6 @@ htparamRender(pHtSession s, pWgtrNode tree, int z)
 	    mssError(1,"HTPARAM","Netscape DOM or W3C DOM1HTML support required");
 	    return -1;
 	    }
-
-    	/** Get an id for this. **/
-	id = (HTPARAM.idcnt++);
 
 	/** Get name and type **/
 	if (wgtrGetPropertyValue(tree,"name",DATA_T_STRING,POD(&ptr)) != 0)
@@ -176,8 +164,6 @@ htparamInitialize()
 	htrRegisterDriver(drv);
 
 	htrAddSupport(drv, "dhtml");
-
-	HTPARAM.idcnt = 0;
 
     return 0;
     }

--- a/centrallix/htmlgen/htdrv_rule.c
+++ b/centrallix/htmlgen/htdrv_rule.c
@@ -65,7 +65,6 @@ typedef struct _RD
 /** globals **/
 static struct 
     {
-    int			idcnt;
     pHtRuleDefinition	RuletypeList;
     }
     HTRULE;
@@ -76,7 +75,6 @@ static struct
 int
 htruleRender(pHtSession s, pWgtrNode tree, int z)
     {
-    int id;
     char* nptr;
     char* ptr;
     pXString xs = NULL;
@@ -89,9 +87,6 @@ htruleRender(pHtSession s, pWgtrNode tree, int z)
     pExpression code;
     pHtRuleDefinition def;
     int i, found;
-
-    	/** Get an id for this. **/
-	id = (HTRULE.idcnt++);
 
 	xs = (pXString)nmMalloc(sizeof(XString));
 	if (!xs) goto error;
@@ -275,7 +270,6 @@ htruleInitialize()
 
 	htrAddSupport(drv, "dhtml");
 
-	HTRULE.idcnt = 0;
 	HTRULE.RuletypeList = NULL;
 
     return 0;

--- a/centrallix/htmlgen/htdrv_timer.c
+++ b/centrallix/htmlgen/htdrv_timer.c
@@ -43,15 +43,6 @@
 /************************************************************************/
 
 
-/** globals **/
-static struct 
-    {
-    int		idcnt;
-    }
-    HTTM;
-
-
-
 /*** httmRender - generate the HTML code for the timer nonvisual widget.
  ***/
 int
@@ -59,7 +50,6 @@ httmRender(pHtSession s, pWgtrNode tree, int z)
     {
     char* ptr;
     char name[64];
-    int id;
     int msec;
     int auto_reset = 0;
     int auto_start = 1;
@@ -69,9 +59,6 @@ httmRender(pHtSession s, pWgtrNode tree, int z)
 	    mssError(1,"HTTM","Netscape 4.x or W3C DOM support required");
 	    return -1;
 	    }
-
-    	/** Get an id for this. **/
-	id = (HTTM.idcnt++);
 
 	/** Get msec for timer countdown **/
 	if (wgtrGetPropertyValue(tree,"msec",DATA_T_INTEGER,POD(&msec)) != 0)
@@ -131,8 +118,6 @@ httmInitialize()
 	htrRegisterDriver(drv);
 
 	htrAddSupport(drv, "dhtml");
-
-	HTTM.idcnt = 0;
 
     return 0;
     }

--- a/centrallix/htmlgen/htdrv_uawindow.c
+++ b/centrallix/htmlgen/htdrv_uawindow.c
@@ -41,20 +41,11 @@
 /************************************************************************/
 
 
-/** globals **/
-static struct 
-    {
-    int		idcnt;
-    }
-    HTUAWIN;
-
-
 /*** htuawinRender - generate the HTML code for the page.
  ***/
 int
 htuawinRender(pHtSession s, pWgtrNode tree, int z)
     {
-    int id;
     char name[64];
     int is_shared = 0;
     int is_multi = 0;
@@ -63,9 +54,6 @@ htuawinRender(pHtSession s, pWgtrNode tree, int z)
     int width = 640;
     int height = 480;
     char* ptr;
-
-    	/** Get an id for this. **/
-	id = (HTUAWIN.idcnt++);
 
 	/** Get name **/
 	if (wgtrGetPropertyValue(tree,"name",DATA_T_STRING,POD(&ptr)) != 0) return -1;
@@ -136,8 +124,6 @@ htuawinInitialize()
 	htrRegisterDriver(drv);
 
 	htrAddSupport(drv, "dhtml");
-
-	HTUAWIN.idcnt = 0;
 
     return 0;
     }

--- a/centrallix/htmlgen/htdrv_variable.c
+++ b/centrallix/htmlgen/htdrv_variable.c
@@ -42,14 +42,6 @@
 /************************************************************************/
 
 
-/** globals **/
-static struct 
-    {
-    int		idcnt;
-    }
-    HTVBL;
-
-
 /*** htvblRender - generate the HTML code for the page.
  ***/
 int
@@ -60,14 +52,11 @@ htvblRender(pHtSession s, pWgtrNode tree, int z)
     char fieldname[HT_FIELDNAME_SIZE];
     char form[64];
     int t;
-    int id, i;
+    int i;
     int n = 0;
     char* vptr = NULL;
     int is_null = 1;
     pExpression code;
-
-    	/** Get an id for this. **/
-	id = (HTVBL.idcnt++);
 
 	/** Get name **/
 	if (wgtrGetPropertyValue(tree,"name",DATA_T_STRING,POD(&ptr)) != 0) return -1;
@@ -154,8 +143,6 @@ htvblInitialize()
 	htrRegisterDriver(drv);
 
 	htrAddSupport(drv, "dhtml");
-
-	HTVBL.idcnt = 0;
 
     return 0;
     }

--- a/centrallix/htmlgen/htdrv_window.c
+++ b/centrallix/htmlgen/htdrv_window.c
@@ -61,7 +61,7 @@ htwinRender(pHtSession s, pWgtrNode tree, int z)
     char name[64];
     pWgtrNode sub_tree;
     int x,y,w,h;
-    int tbw,tbh,bx,by,bw,bh;
+    int tbw,tbh;//bx,by,bw,bh;
     int id, i;
     int visible = 1;
     char bgnd_style[128] = "";
@@ -223,28 +223,28 @@ htwinRender(pHtSession s, pWgtrNode tree, int z)
 	    }
 
 	/** Compute window body geometry **/
-	if (is_dialog_style)
-	    {
-	    bx = 1;
-	    by = 1+tbh;
-	    bw = w-2;
-	    bh = h-tbh-2;
-	    }
-	else
-	    {
-	    bx = 2;
-	    bw = w-4;
-	    if (has_titlebar)
-		{
-		by = 1+tbh;
-		bh = h-tbh-3;
-		}
-	    else
-		{
-		by = 2;
-		bh = h-4;
-		}
-	    }
+	// if (is_dialog_style)
+	//     {
+	//     bx = 1;
+	//     by = 1+tbh;
+	//     bw = w-2;
+	//     bh = h-tbh-2;
+	//     }
+	// else
+	//     {
+	//     bx = 2;
+	//     bw = w-4;
+	//     if (has_titlebar)
+	// 	{
+	// 	by = 1+tbh;
+	// 	bh = h-tbh-3;
+	// 	}
+	//     else
+	// 	{
+	// 	by = 2;
+	// 	bh = h-4;
+	// 	}
+	//     }
 
 	/** Draw the main window layer and outer edge. **/
 	/*htrAddStylesheetItem_va(s,"\t#wn%POSbase { POSITION:absolute; VISIBILITY:%STR; LEFT:%INTpx; TOP:%INTpx; WIDTH:%POSpx; HEIGHT:%POSpx; overflow: hidden; clip:rect(0px, %INTpx, %INTpx, 0px); Z-INDEX:%POS;}\n",

--- a/centrallix/multiquery/multiq_equijoin.c
+++ b/centrallix/multiquery/multiq_equijoin.c
@@ -948,7 +948,7 @@ mqj_internal_NextItem_r(pQueryElement qe, pQueryStatement stmt, int source_id)
     pMqjJoinExec src, nextsrc, checksrc;
     int rval = 1;
     unsigned int null_dep_mask;
-    bool can_be_outer = false, is_outer = false;
+    bool can_be_outer = false; //, is_outer = false;
     pMqjJoinData md = (pMqjJoinData)(qe->PrivateData);
     int j;
 
@@ -960,8 +960,8 @@ mqj_internal_NextItem_r(pQueryElement qe, pQueryStatement stmt, int source_id)
 	null_dep_mask = (~md->StartedStateMask) & src->DependencyMask;
 
 	/** Is this source outer joined? **/
-	if (src->OuterMask || (src->DependencyMask != 0 && (src->DependencyMask & md->OuterStateMask) == src->DependencyMask))
-	    is_outer = true;
+	// if (src->OuterMask || (src->DependencyMask != 0 && (src->DependencyMask & md->OuterStateMask) == src->DependencyMask))
+	//     is_outer = true;
 	can_be_outer = (md->CanBeOuterMask & src->CoverageMask)?true:false;
 
 	/** Already done with this source? **/

--- a/centrallix/multiquery/multiq_orderby.c
+++ b/centrallix/multiquery/multiq_orderby.c
@@ -543,7 +543,6 @@ mqobFinish(pQueryElement qe, pQueryStatement stmt)
     {
     pMQOData context = (pMQOData)(qe->PrivateData);
     pMqobOrderable item;
-    pParamObjects objlist;
     pQueryElement cld;
     int i;
 

--- a/centrallix/netdrivers/net_http.c
+++ b/centrallix/netdrivers/net_http.c
@@ -1821,7 +1821,6 @@ nht_i_GET(pNhtConn conn, pStruct url_inf, char* if_modified_since)
     char* slashptr;
     pNhtApp app = NULL;
     pNhtAppGroup group = NULL;
-    int rval;
     char* kname;
     pXString err_xs;
 
@@ -2329,7 +2328,7 @@ nht_i_GET(pNhtConn conn, pStruct url_inf, char* if_modified_since)
 	else if (!strcmp(find_inf->StrVal,"rest"))
 	    {
 	    conn->StrictSameSite = 0;
-	    rval = nht_i_RestGet(conn, url_inf, target_obj);
+	    nht_i_RestGet(conn, url_inf, target_obj);
 	    }
 
 	/** Retrieve a new session/group/app key? **/

--- a/centrallix/osdrivers/objdrv_qytree.c
+++ b/centrallix/osdrivers/objdrv_qytree.c
@@ -1325,8 +1325,6 @@ qytQueryFetch(void* qy_v, pObject obj, int mode, pObjTrxTree* oxt)
     pQytQuery qy = ((pQytQuery)(qy_v));
     pQytData inf;
     pObject llobj = NULL;
-    pStructInf find_inf;
-    char* ptr;
     char* objname = NULL;
     int cur_id = -1;
 
@@ -1883,4 +1881,3 @@ qytInitialize()
 
     return 0;
     }
-

--- a/centrallix/tests/t_driver.c
+++ b/centrallix/tests/t_driver.c
@@ -50,7 +50,7 @@ print_result(char * result, bool succeeded)
     #ifdef HAVE_NCURSES
     if (use_curses) {
         // Clear blue color from stderr
-        tputs(tparm(tigetstr("sgr0")), 1, puterr);
+        tputs(tparm(tigetstr("sgr0")), 1, (int(*)(int))puterr);
     }
     #endif
 
@@ -110,7 +110,7 @@ start(void* v)
 
     if (use_curses) {
         // Set any error output to be blue
-        tputs(tparm(tigetstr("setaf"), COLOR_BLUE), 1, puterr);
+        tputs(tparm(tigetstr("setaf"), COLOR_BLUE), 1, (int(*)(int))puterr);
     }
     #endif
 
@@ -132,4 +132,3 @@ main(int argc, char* argv[])
     mtInitialize(0, start);
     return 0;
     }
-

--- a/centrallix/tests/test_cxss_hexify_00.c
+++ b/centrallix/tests/test_cxss_hexify_00.c
@@ -26,7 +26,7 @@ test_hexify(char* str, char* cmp, int dstbuflen, int cmprval)
     buf1[len+2+2] = 0;
     memset(buf2, 127, sizeof(buf2));
 
-    rval = cxssHexify(buf1+2, len, buf2+2, dstbuflen);
+    rval = cxssHexify((unsigned char*)buf1+2, len, buf2+2, dstbuflen);
 
     assert(rval == cmprval);
     assert(buf1[0] == 0);

--- a/centrallix/tests/test_cxss_hexify_01.c
+++ b/centrallix/tests/test_cxss_hexify_01.c
@@ -26,7 +26,7 @@ test_hexify(char* str, char* cmp, int dstlen, int cmprval)
     buf1[len+2+2] = 0;
     memset(buf2, 127, sizeof(buf2));
 
-    rval = cxss_i_Hexify(buf1+2, len, buf2+2, dstlen);
+    rval = cxss_i_Hexify((unsigned char*)buf1+2, len, buf2+2, dstlen);
 
     assert(rval == cmprval);
     assert(buf1[0] == 0);

--- a/centrallix/tests/test_cxss_hexify_02.c
+++ b/centrallix/tests/test_cxss_hexify_02.c
@@ -21,7 +21,7 @@ test_hexify(char* str, char* cmp, int dstlen, int cmprval)
     memset(buf1, 127, sizeof(buf1));
     strcpy(buf1+2, str);
 
-    rval = cxss_i_Hexify(buf1+2, len, buf1+2, dstlen);
+    rval = cxss_i_Hexify((unsigned char*)buf1+2, len, buf1+2, dstlen);
 
     assert(rval == cmprval);
 

--- a/centrallix/utility/json_util.c
+++ b/centrallix/utility/json_util.c
@@ -53,10 +53,10 @@ jutilIsDateTimeObject(struct json_object* jobj)
     int has_year = 0;
     int has_month = 0;
     int has_day = 0;
-    int has_hour = 0;
-    int has_minute = 0;
-    int has_second = 0;
-    int has_tz = 0;
+    // int has_hour = 0;
+    // int has_minute = 0;
+    // int has_second = 0;
+    // int has_tz = 0;
     int has_other = 0;
 
 	/** Must be an 'object' **/
@@ -71,10 +71,10 @@ jutilIsDateTimeObject(struct json_object* jobj)
 		if (!strcmp(iter.key, "year")) has_year = 1;
 		else if (!strcmp(iter.key, "month")) has_month = 1;
 		else if (!strcmp(iter.key, "day")) has_day = 1;
-		else if (!strcmp(iter.key, "hour")) has_hour = 1;
-		else if (!strcmp(iter.key, "minute")) has_minute = 1;
-		else if (!strcmp(iter.key, "second")) has_second = 1;
-		else if (!strcmp(iter.key, "tzoffset")) has_tz = 1;
+		else if (!strcmp(iter.key, "hour")); // has_hour = 1;
+		else if (!strcmp(iter.key, "minute")); // has_minute = 1;
+		else if (!strcmp(iter.key, "second")); // has_second = 1;
+		else if (!strcmp(iter.key, "tzoffset")); // has_tz = 1;
 		else has_other = 1;
 		}
 	    else    
@@ -101,10 +101,10 @@ jutilGetDateTimeObject(struct json_object* jobj, pDateTime dt)
     int has_year = 0;
     int has_month = 0;
     int has_day = 0;
-    int has_hour = 0;
-    int has_minute = 0;
-    int has_second = 0;
-    int has_tz = 0;
+    // int has_hour = 0;
+    // int has_minute = 0;
+    // int has_second = 0;
+    // int has_tz = 0;
     int has_other = 0;
 
 	/** Must be an 'object' **/
@@ -134,22 +134,22 @@ jutilGetDateTimeObject(struct json_object* jobj, pDateTime dt)
 		    }
 		else if (!strcmp(iter.key, "hour"))
 		    {
-		    has_hour = 1;
+		    // has_hour = 1;
 		    dt->Part.Hour = json_object_get_int(iter.val);
 		    }
 		else if (!strcmp(iter.key, "minute"))
 		    {
-		    has_minute = 1;
+		    // has_minute = 1;
 		    dt->Part.Minute = json_object_get_int(iter.val);
 		    }
 		else if (!strcmp(iter.key, "second"))
 		    {
-		    has_second = 1;
+		    // has_second = 1;
 		    dt->Part.Second = json_object_get_int(iter.val);
 		    }
 		else if (!strcmp(iter.key, "tzoffset"))
 		    {
-		    has_tz = 1;
+		    // has_tz = 1;
 		    }
 		else
 		    {
@@ -257,5 +257,3 @@ jutilGetMoneyObject(struct json_object* jobj, pMoneyType m)
 
     return -1;
     }
-
-

--- a/centrallix/wgtr/apos.c
+++ b/centrallix/wgtr/apos.c
@@ -1260,7 +1260,7 @@ pWgtrNode Widget;
 int
 aposProcessWindows(pWgtrNode VisualRef, pWgtrNode Parent)
 {
-int i=0, changed=0, isWin=0, isSP=0;
+int i=0, isWin=0, isSP=0;
 int childCount=xaCount(&(Parent->Children));
 pWgtrNode Child;
 int rw, rh, rpw, rph;
@@ -1302,32 +1302,25 @@ int ival;
 			{
 			    Child->x = (rw - Child->width)/2;
 			    if (Child->x < 0) Child->x = 0;
-			    changed = 1;
 			}
 		    if (abs(Child->pre_y - (rph - (Child->pre_y + Child->pre_height))) < 10)
 			{
 			    Child->y = (rh - Child->height)/2;
 			    if (Child->y < 0) Child->y = 0;
-			    changed = 1;
 			}
 
 		    /**if it's larger than its container, shrink it and set flag**/
 		    if(Child->width > (rw - isSP*18))
 		        {
 			    Child->width = (rw - isSP*18);
-			    changed = 1;
 			}
 		    if(Child->height > (rh - isWin*24))
 			{
 			    Child->height = (rh - isWin*24);
-			    changed = 1;
 			}
 		    
 		    /**if the window changed width or height, process it like a widget tree**/
-		    //if(changed) 
 		    aposAutoPositionWidgetTree(Child);
-		    /*Child->width = Child->pre_width;
-		    Child->height = Child->pre_height;*/
 
 		    /**if it's outside the top left corner pull the whole window in**/
 		    if(Child->x < 0) Child->x = 0;

--- a/centrallix/wgtr/apos.c
+++ b/centrallix/wgtr/apos.c
@@ -311,7 +311,7 @@ int rval;
 
     rval = aposSetLimits_r(Parent, &delta_w, &delta_h);
 
-    return 0;
+    return rval;
 }
 
 
@@ -682,8 +682,8 @@ pXArray FirstCross, LastCross;
     /**sanity check to make sure no widgets cross the border lines**/
     if(xaCount(HLines))	//don't test borderlines unless they exist
 	{
-	    FirstCross = &(((pAposLine)xaGetItem(HLines, 0))->CWidgets);
-	    LastCross  = &(((pAposLine)xaGetItem(HLines, (xaCount(HLines)-1)))->CWidgets);
+	//     FirstCross = &(((pAposLine)xaGetItem(HLines, 0))->CWidgets);
+	//     LastCross  = &(((pAposLine)xaGetItem(HLines, (xaCount(HLines)-1)))->CWidgets);
 	    /*if(xaCount(FirstCross))
 		mssError(1, "APOS", "%d widget(s) crossed the top borderline, including %s '%s'", xaCount(FirstCross),
 		    ((pWgtrNode)xaGetItem(FirstCross, 0))->Type, ((pWgtrNode)xaGetItem(FirstCross, 0))->Name);
@@ -692,8 +692,8 @@ pXArray FirstCross, LastCross;
 		    ((pWgtrNode)xaGetItem(LastCross, 0))->Type, ((pWgtrNode)xaGetItem(LastCross, 0))->Name);*/
 	}
 	
-    FirstCross = &(((pAposLine)xaGetItem(VLines, 0))->CWidgets);
-    LastCross  = &(((pAposLine)xaGetItem(VLines, (xaCount(VLines)-1)))->CWidgets);
+//     FirstCross = &(((pAposLine)xaGetItem(VLines, 0))->CWidgets);
+//     LastCross  = &(((pAposLine)xaGetItem(VLines, (xaCount(VLines)-1)))->CWidgets);
     /*if(xaCount(FirstCross))
 	mssError(1, "APOS", "%d widget(s) crossed the left borderline, including %s '%s'", xaCount(FirstCross), 
 	    ((pWgtrNode)xaGetItem(FirstCross, 0))->Type, ((pWgtrNode)xaGetItem(FirstCross, 0))->Name);

--- a/centrallix/wgtr/apos.c
+++ b/centrallix/wgtr/apos.c
@@ -542,7 +542,7 @@ aposAutoPositionContainers(pWgtrNode Parent)
 pAposGrid theGrid;
 pWgtrNode Child;
 int i=0, childCount = xaCount(&(Parent->Children));
-int rows_extra=0, cols_extra=0;
+// int rows_extra=0, cols_extra=0;
 
     /** Check recursion **/
     if (thExcessiveRecursion())
@@ -559,9 +559,11 @@ int rows_extra=0, cols_extra=0;
 	{
 	    /**Adjust the spaces between lines to fit the grid to the container**/
 	    if (!(Parent->Flags & WGTR_F_VSCROLLABLE))
-		rows_extra = aposSpaceOutLines(&(theGrid->HLines), &(theGrid->Rows), (Parent->height - Parent->pre_height));	//rows
+		// rows_extra =
+		aposSpaceOutLines(&(theGrid->HLines), &(theGrid->Rows), (Parent->height - Parent->pre_height));	//rows
 	    if (!(Parent->Flags & WGTR_F_HSCROLLABLE))
-		cols_extra = aposSpaceOutLines(&(theGrid->VLines), &(theGrid->Cols), (Parent->width - Parent->pre_width));	 //columns
+		// cols_extra =
+		aposSpaceOutLines(&(theGrid->VLines), &(theGrid->Cols), (Parent->width - Parent->pre_width));	 //columns
 	    
 	    /**modify the widgets' x,y,w, and h values to snap to their adjusted lines**/
 	    if (!(Parent->Flags & WGTR_F_VSCROLLABLE))
@@ -633,7 +635,7 @@ aposAddLinesToGrid(pWgtrNode Parent, pXArray HLines, pXArray VLines)
 {
 int i=0, count=0, isWin=0, isSP=0, height_adj=0, width_adj=0;
 pAposLine CurrLine, PrevLine;
-pXArray FirstCross, LastCross;
+// pXArray FirstCross, LastCross;
 
     aposSetOffsetBools(Parent, &isSP, &isWin, NULL, NULL, NULL);
 


### PR DESCRIPTION
This PR greatly reduces / nearly eliminates warnings when building centrallix, centrallix-lib, and their associated test suites with default configuration flags. This will reduce the number of bugs that make it to production in the future by making legitimate warnings far more obvious when building the project.