### PR TITLE
Include mssError() when used

### DIFF
--- a/centrallix/cxss/cxss_credentials_db.c
+++ b/centrallix/cxss/cxss_credentials_db.c
@@ -6,6 +6,7 @@
 #include <sqlite3.h>
 #include "cxss/credentials_db.h"
 #include "cxss/util.h"
+#include "cxlib/mtsession.h"
 
 /* Private functions (credentials_db) */
 static int cxss_i_SetupCredentialsDatabase(CXSS_DB_Context_t dbcontext);
@@ -1043,4 +1044,3 @@ cxss_i_FinalizeSqliteStatements(CXSS_DB_Context_t dbcontext)
     sqlite3_finalize(dbcontext->update_resc_stmt);
     sqlite3_finalize(dbcontext->delete_resc_stmt);
 }
-

--- a/centrallix/cxss/cxss_crypto.c
+++ b/centrallix/cxss/cxss_crypto.c
@@ -10,6 +10,7 @@
 #include <openssl/pem.h>
 #include "cxss/crypto.h"
 #include "cxss/credentials_db.h"
+#include "cxlib/mtsession.h"
 
 static bool CSPRNG_Initialized = false;
 
@@ -502,4 +503,3 @@ cxssDestroyKey(char *key, size_t keylength)
         free(key);
     }
 }
-

--- a/centrallix/cxss/cxss_util.c
+++ b/centrallix/cxss/cxss_util.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <time.h>
 #include "cxss/util.h"
+#include "cxlib/mtsession.h"
 
 /** @brief Duplicate a string
  *
@@ -84,4 +85,3 @@ cxssGetTimestamp(void)
     }
     return timestamp;
 }
-

--- a/centrallix/objectsystem/obj_content.c
+++ b/centrallix/objectsystem/obj_content.c
@@ -4,6 +4,7 @@
 #include <fcntl.h>
 #include "obj.h"
 #include "cxlib/mtask.h"
+#include "cxlib/mtsession.h"
 #include "cxlib/xarray.h"
 #include "cxlib/xhash.h"
 #include "cxlib/magic.h"
@@ -88,4 +89,3 @@ objWrite(pObject this, char* buffer, int cnt, int offset, int flags)
 	}
     return this->Driver->Write(this->Data, buffer, cnt, offset, flags, &(this->Session->Trx));
     }
-

--- a/centrallix/objectsystem/obj_session.c
+++ b/centrallix/objectsystem/obj_session.c
@@ -4,6 +4,7 @@
 #include <fcntl.h>
 #include "obj.h"
 #include "cxlib/mtask.h"
+#include "cxlib/mtsession.h"
 #include "cxlib/xarray.h"
 #include "cxlib/xhash.h"
 #include "cxlib/magic.h"
@@ -257,4 +258,3 @@ objResumeTransaction(pObjSession this, pObjTrxTree trx)
 
     return 0;
     }
-

--- a/centrallix/osdrivers/objdrv_shell.c
+++ b/centrallix/osdrivers/objdrv_shell.c
@@ -4,6 +4,7 @@
 #include <fcntl.h>
 #include "obj.h"
 #include "cxlib/mtask.h"
+#include "cxlib/mtsession.h"
 #include "cxlib/xarray.h"
 #include "cxlib/xhash.h"
 #include "stparse.h"
@@ -1254,4 +1255,3 @@ MODULE_PREFIX("shl");
 MODULE_DESC("SHL ObjectSystem Driver");
 MODULE_VERSION(0,1,0);
 MODULE_IFACE(CX_CURRENT_IFACE);
-

--- a/centrallix/utility/obfuscate.c
+++ b/centrallix/utility/obfuscate.c
@@ -8,6 +8,7 @@
 #include "cxlib/mtask.h"
 #include "cxlib/strtcpy.h"
 #include "cxlib/mtlexer.h"
+#include "cxlib/mtsession.h"
 #include "cxlib/xhash.h"
 #include "obj.h"
 #include "cxss/cxss.h"
@@ -1371,5 +1372,3 @@ obfObfuscateDataSess(pObfSession sess, pObjData srcval, pObjData dstval, int dat
 
     return rval;
     }
-
-

--- a/centrallix/utility/param.c
+++ b/centrallix/utility/param.c
@@ -6,6 +6,7 @@
 #include "cxlib/strtcpy.h"
 #include "cxlib/newmalloc.h"
 #include "cxlib/datatypes.h"
+#include "cxlib/mtsession.h"
 #include "stparse.h"
 #include "stparse_ne.h"
 #include "param.h"
@@ -414,4 +415,3 @@ paramGetValue(pParam param, int datatype, pObjData value)
 
     return paramGetValueUntyped(param, value);
     }
-

--- a/centrallix/utility/ptod.c
+++ b/centrallix/utility/ptod.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include "cxlib/datatypes.h"
 #include "cxlib/newmalloc.h"
+#include "cxlib/mtsession.h"
 #include "ptod.h"
 #include "obj.h"
 
@@ -303,4 +304,3 @@ ptodTypeOf(pTObjData ptod)
     {
     return ptod->DataType;
     }
-

--- a/centrallix/wgtr/apos.c
+++ b/centrallix/wgtr/apos.c
@@ -36,6 +36,7 @@
 #include "apos.h"
 #include "cxlib/xarray.h"
 #include "cxlib/datatypes.h"
+#include "cxlib/mtsession.h"
 
 int
 aposInit()

--- a/centrallix/wgtr/wgtr.c
+++ b/centrallix/wgtr/wgtr.c
@@ -46,6 +46,7 @@
 #include "cxlib/magic.h"
 #include "cxlib/xhash.h"
 #include "cxlib/strtcpy.h"
+#include "cxlib/mtsession.h"
 #include "ht_render.h"
 
 #define WGTR_MAX_PARAMS		(24)


### PR DESCRIPTION
Some files call `msError()` without including `cxlib/mtsession.h`. This latent mistake caused compiler errors when I made an otherwise safe change in code I plan to commit to for #77 once it's not being reviewed.

I'm making this a new PR because I don't want to mix even more mostly unrelated changes into the `dups` branch, and I think these changes will be obviously safe on their own, so they should be trivial to review, approve, and merge.