### PR TITLE
Fix Widget Docs

### DIFF
--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -2589,6 +2589,57 @@ myMenu "widget/menu"
 	</widget>
 
 
+	<widget name="objcanvas" type="widget/objcanvas" visual="yes" formelement="no" container="yes" description="A visual widget for advanced canvas-based graphics.">
+
+		<overview>
+
+			<p>The objcanvas widget is a visual widget for displaying advanced canvas graphics.</p>
+
+		</overview>
+
+		<usage>
+
+			<p>The objcanvas widget is a visual that contains Centrallix objects.  I honestly don't really understand how to use it or what it does (-Israel).</p>
+
+		</usage>
+
+		<properties>
+
+			<property name="width" type="integer">Width (in pixels) of the objcanvas.</property>
+
+			<property name="x" type="integer">X-coordinate of the upper left corner of the objcanvas (in pixels), relative to its container.</property>
+
+			<property name="y" type="integer">Y-coordinate of the upper left corner of the objcanvas (in pixels), relative to its container.</property>
+
+			<property name="height" type="integer">Height (in pixels) of the objcanvas.</property>
+
+			<property name="source" type="string">A Centrallix object source path that we open to get the objects that will be rendered in the objcanvas widget.</property>
+
+			<property name="allow_selection" type="integer">Not implemented yet: Specify 1 to enable something... (default: 0)</property>
+
+			<property name="show_selection" type="integer">Not implemented yet: Specify 1 to enable something... (default: 0)</property>
+
+		</properties>
+
+		<events>
+
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
+
+			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
+
+			<event name="MouseMove">This event occurs when the user moves the mouse pointer while it is over the widget (or content inside the widget).  The event will repeatedly fire each time the pointer moves.</event>
+
+			<event name="MouseOut">This event occurs when the user moves the mouse pointer off of the widget.</event>
+
+			<event name="MouseOver">This event occurs when the user first moves the mouse pointer over the widget.  It will not occur again until the user moves the mouse off of the widget and then back over it again.</event>
+
+			<event name="MouseUp">This event occurs when the user releases the mouse button on the widget.</event>
+
+		</events>
+
+	</widget>
+
+
 	<widget name="osrc" type="widget/osrc" visual="no" formelement="no" container="yes" description="A nonvisual widget which handles data communication between forms/tables and the Centrallix server.">
 
 		<overview>

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding="UTF-8"?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE widgets [
 	<!-- Define the widgets elements. -->
 	<!ELEMENT widgets (widget*)>
@@ -7,7 +6,7 @@
 		overview, usage, properties, clientprops?,
 		children?, events?, actions?, sample?
 	)>
-	
+
 	<!-- Define widget elements. -->
 	<!ELEMENT overview (#PCDATA | p | b | i | ul | ol)*>
 	<!ELEMENT usage (#PCDATA | p | b | i | ul | ol)*>
@@ -23,10 +22,10 @@
 	<!ELEMENT actions (action | note)*>
 	<!ELEMENT action (#PCDATA | ni)*>
 	<!ELEMENT sample (#PCDATA)>
-	
+
 	<!-- Adds context for all properties/events/action/etc. -->
 	<!ELEMENT note (#PCDATA | ni)*>
-	
+
 	<!-- Define HTML elements -->
 	<!ELEMENT p (#PCDATA | b | i | ul | ol)*>
 	<!ELEMENT b (#PCDATA)*>
@@ -37,37 +36,31 @@
 	<!ELEMENT ni (#PCDATA)>
 
 	<!-- Define attribute lists for widget elements. -->
-	<!ATTLIST widget    
-		name           ID         #REQUIRED
-		type           CDATA      #REQUIRED
-		description    CDATA      #IMPLIED
-		visual         (yes|no)   #IMPLIED
-		formelement    (yes|no)   #IMPLIED
-		container      (yes|no)   #IMPLIED
-		osrcclient     (yes|no)   #IMPLIED
+	<!ATTLIST widget
+		name ID #REQUIRED
+		type CDATA #REQUIRED
+		description CDATA #IMPLIED
+		visual (yes|no) #IMPLIED
+		formelement (yes|no) #IMPLIED
+		container (yes|no) #IMPLIED
+		osrcclient (yes|no) #IMPLIED
 	>
 	<!ATTLIST property
-		name           CDATA      #REQUIRED
-		type           CDATA      #REQUIRED
-		subtype        CDATA      #IMPLIED
-		enum           CDATA      #IMPLIED
+		name CDATA #REQUIRED
+		type CDATA #REQUIRED
+		subtype CDATA #IMPLIED
+		enum CDATA #IMPLIED
 	>
-	<!ATTLIST child
-		type           CDATA      #REQUIRED
-	>
+	<!ATTLIST child type CDATA #REQUIRED>
 	<!ATTLIST childproperty
-		name           CDATA      #REQUIRED
-		type           CDATA      #REQUIRED
+		name CDATA #REQUIRED
+		type CDATA #REQUIRED
 	>
-	<!ATTLIST event
-		name           CDATA      #REQUIRED
-	>
-	<!ATTLIST action
-		name           CDATA      #REQUIRED
-	>
+	<!ATTLIST event name CDATA #REQUIRED>
+	<!ATTLIST action name CDATA #REQUIRED>
 	<!ATTLIST clientprop
-		name           CDATA      #REQUIRED
-		type           CDATA      #REQUIRED
+		name CDATA #REQUIRED
+		type CDATA #REQUIRED
 	>
 ]>
 
@@ -95,8 +88,8 @@
 
 		<properties>
 
-			<property name="align" type="string">Sets the alignment of text  can have left (default) right or center.</property>
-		
+			<property name="align" type="string">Sets the alignment of text can have left (default) right or center.</property>
+
 			<property name="cellsize" type="integer">For an hbox, this is the width to use for the child widgets (unless otherwise specified by the child widget).  For a vbox, this refers to the height to use for child widgets unless otherwise specified.</property>
 
 			<property name="column_width" type="integer">This specifies the width of columns for a vbox -- should the first column of widgets fill up, a second column will be started at this offset from the start of the first column.</property>
@@ -104,7 +97,7 @@
 			<property name="height" type="integer">Height, in pixels, of the autolayout area.  If omitted, it defaults to the maximum available height for the given width, without overlapping other visible widgets.  If both width and height are unspecified, Centrallix will chose a width and height that maximize the available autolayout area.</property>
 
 			<property name="justify" type="string">Makes the text fill page (justifies text - google it if you need).</property>
-			
+
 			<property name="row_height" type="integer">This specifies the height of rows for an hbox -- should the first row of widgets fill up horizontally, a second row will be started beneath the first one, at this vertical offset from the start of the first row.</property>
 
 			<property name="spacing" type="integer">The spacing, in pixels, between widgets.  For an hbox, this refers to the horizontal spacing between children.  For a vbox, this refers to the vertical spacing.</property>
@@ -124,30 +117,18 @@
 			<child type="any">
 
 				<childproperty name="autolayout_order" type="integer">An optional property, this allows the layout sequence of child widgets to be controlled, and the children are placed in ascending order.  If unspecified, this defaults to a value of 100 for the first child encountered, or to N+1 where N is the autolayout sequence of the most recent child widget encountered.</childproperty>
-				
+
 				<childproperty name="height" type="integer">Height, in pixels, of the child.</childproperty>
-				
+
 				<childproperty name="width" type="integer">Width, in pixels, of the child.</childproperty>
 
 			</child>
 
 		</children>
 
-		<events>
-
-		</events>
-
-		<actions>
-
-		</actions>
-
-		<clientprops>
-
-		</clientprops>
-
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 // Here is a vbox which can have up to three
 
@@ -165,71 +146,72 @@ vbox1 "widget/vbox"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="button" type="widget/button" visual="yes" container="no" formelement="no" description="A multipurpose button">
 
-	    <overview>
+		<overview>
 
-		<p>Combines the functionality of the textbutton and imagebutton, as well as adding the ability to have both text and image displayed in a button.</p>
+			<p>Combines the functionality of the textbutton and imagebutton, as well as adding the ability to have both text and image displayed in a button.</p>
 
-	    </overview>
+		</overview>
 
-	    <usage>
+		<usage>
 
-		<p>A Button can be placed inside any visible container, but only nonvisual widgets can be placed within it.  Properties that don't apply to the button's type are ignored.</p>
+			<p>A Button can be placed inside any visible container, but only nonvisual widgets can be placed within it.  Properties that don't apply to the button's type are ignored.</p>
 
-	    </usage>
+		</usage>
 
-	    <properties>
+		<properties>
 
-		<property name="bgcolor" type="string">A color, RGB or named, to be used as the button's background.If neither bgcolor nor background are specified, the button is transparent.</property>
+			<property name="bgcolor" type="string">A color, RGB or named, to be used as the button's background.If neither bgcolor nor background are specified, the button is transparent.</property>
 
-		<property name="clickimage" type="string">The ObjectSystem pathname of the image to be shown when the user clicks the imagebutton.  Defaults to 'image' if not specified.</property>
+			<property name="clickimage" type="string">The ObjectSystem pathname of the image to be shown when the user clicks the imagebutton.  Defaults to 'image' if not specified.</property>
 
-		<property name="disable_color" type="string">A color, RGB or named, to be used for the button's text when it is disabled.</property>
+			<property name="disable_color" type="string">A color, RGB or named, to be used for the button's text when it is disabled.</property>
 
-		<property name="disabledimage" type="string">The ObjectSystem pathname of the image to be shown when the imagebutton is disabled.  Defaults to 'image' if not specified.</property>
+			<property name="disabledimage" type="string">The ObjectSystem pathname of the image to be shown when the imagebutton is disabled.  Defaults to 'image' if not specified.</property>
 
-		<property name="enabled" type="yes/no or expr">Whether the button is enabled (can be clicked).  Default is 'yes'.  Also supports dynamic runclient() expressions allowing the enabled status of the button to follow the value of an expression.</property>
+			<property name="enabled" type="yes/no or expr">Whether the button is enabled (can be clicked).  Default is 'yes'.  Also supports dynamic runclient() expressions allowing the enabled status of the button to follow the value of an expression.</property>
 
-		<property name="fgcolor1" type="string">A color, RGB or named, for the text on the button.  Default "white".</property>
+			<property name="fgcolor1" type="string">A color, RGB or named, for the text on the button.  Default "white".</property>
 
-		<property name="fgcolor2" type="string">A color, RGB or named, for the text's 1-pixel drop-shadow.  Default "black".</property>
+			<property name="fgcolor2" type="string">A color, RGB or named, for the text's 1-pixel drop-shadow.  Default "black".</property>
 
-		<property name="height" type="integer">Height, in pixels, of the text button.</property>
+			<property name="height" type="integer">Height, in pixels, of the text button.</property>
 
-		<property name="image" type="string">The pathname of the image to be shown when the button is "idle".</property>
+			<property name="image" type="string">The pathname of the image to be shown when the button is "idle".</property>
 
-		<property name="pointimage" type="string">The pathname of the image to be shown when the button is pointed-to.  Defaults to  the 'image' if not specified.</property>
-		
-		<property name="spacing" type="integer">The distance between the image and text if applicable.</property>
+			<property name="pointimage" type="string">The pathname of the image to be shown when the button is pointed-to.  Defaults to the 'image' if not specified.</property>
 
-		<property name="text" type="string">The text to appear on the button.</property>
+			<property name="spacing" type="integer">The distance between the image and text if applicable.</property>
 
-		<property name="tristate" type="yes/no">Whether or not the button is tri-state (does not display a raised border until the user points at it). Default is yes.</property>
+			<property name="text" type="string">The text to appear on the button.</property>
 
-		<property name="type" type="string">There are currently 7 different types.  1) text 2) image 3) topimage (image above text) 4) rightimage 5) leftimage 6) bottomimage 7) textoverimage (text over image background).</property>	
+			<property name="tristate" type="yes/no">Whether or not the button is tri-state (does not display a raised border until the user points at it).  Default is yes.</property>
 
-		<property name="width" type="integer">The width, in pixels, of the text button.</property>
+			<property name="type" type="string">There are currently 7 different types: 1) text 2) image 3) topimage (image above text) 4) rightimage 5) leftimage 6) bottomimage 7) textoverimage (text over image background).</property>
 
-		<property name="x" type="integer">X-coordinate of the upper left corner of the button, relative to its container.</property>
+			<property name="width" type="integer">The width, in pixels, of the text button.</property>
 
-		<property name="y" type="integer">Y-coordinate of the upper left corner of the button, relative to its container.</property>
+			<property name="x" type="integer">X-coordinate of the upper left corner of the button, relative to its container.</property>
 
-	    </properties>
-		
+			<property name="y" type="integer">Y-coordinate of the upper left corner of the button, relative to its container.</property>
+
+		</properties>
+
 		<children>
 
 		</children>
 
 		<events>
-		
-			<event name="Click">This event occurs when the user clicks the widget. No parameters are available from this event.</event>
+
+			<event name="Click">This event occurs when the user clicks the widget.  No parameters are available from this event.</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
@@ -238,28 +220,13 @@ vbox1 "widget/vbox"
 			<event name="MouseOver">This event occurs when the user first moves the mouse pointer over the widget.  It will not occur again until the user moves the mouse off of the widget and then back over it again.</event>
 
 			<event name="MouseOut">This event occurs when the user moves the mouse pointer off of the widget.</event>
-			
+
 			<event name="MouseUp">This event occurs when the user releases the mouse button on the widget.</event>
 
 		</events>
 
-		<actions>
-
-		</actions>
-
-		<clientprops>
-
-		</clientprops>
-
-		<sample>
-
-		<![CDATA[
-
-		]]>
-
-		</sample>
-
 	</widget>
+
 
 	<widget name="calendar" type="widget/calendar" description="Calendar-type view of event/schedule type data in an objectsource" visual="yes" formelement="no" container="no" osrcclient="yes">
 
@@ -269,13 +236,13 @@ vbox1 "widget/vbox"
 
 			<ul>
 
-			    <li><b>Year</b> - Presents twelve months at a time in a low-detail type of setting; when events occur on a day, the day is highlighted, but no more data than that is displayed.  If the user points the mouse at a given day, it will display in a popup "tooltip" type of manner the events associated with that day.  If more than one year's worth of data is in the objectsource's replica, then multiple years are displayed one after the other.  Each year is displayed as four rows of three months each, in traditional calendar format.</li>
+				<li><b>Year</b> - Presents twelve months at a time in a low-detail type of setting; when events occur on a day, the day is highlighted, but no more data than that is displayed.  If the user points the mouse at a given day, it will display in a popup "tooltip" type of manner the events associated with that day.  If more than one year's worth of data is in the objectsource's replica, then multiple years are displayed one after the other.  Each year is displayed as four rows of three months each, in traditional calendar format.</li>
 
-			    <li><b>Month</b> - Presents one month's worth of data in a medium-detail display.  For each month with data in the objectsource, the calendar will display the month as multiple rows, each row containing one week's worth of days.  The calendar will attempt to display the various entries for each day, in order of priority, but will limit the amount of data displayed to keep the boxes for the days approximately visually square.  Pointing at a day will show the events for the day in a popup, and pointing at an event in the day will show the details for that event.</li>
+				<li><b>Month</b> - Presents one month's worth of data in a medium-detail display.  For each month with data in the objectsource, the calendar will display the month as multiple rows, each row containing one week's worth of days.  The calendar will attempt to display the various entries for each day, in order of priority, but will limit the amount of data displayed to keep the boxes for the days approximately visually square.  Pointing at a day will show the events for the day in a popup, and pointing at an event in the day will show the details for that event.</li>
 
-			    <li><b>Week</b> - Presents one week's worth of data in a high-detail display.  For each week with data in the objectsource, the calendar will display the week as seven days with a large vertical extent capable of displaying all events for the day.  The left edge of the display will contain times during the day for the day's events to line up with.</li>
+				<li><b>Week</b> - Presents one week's worth of data in a high-detail display.  For each week with data in the objectsource, the calendar will display the week as seven days with a large vertical extent capable of displaying all events for the day.  The left edge of the display will contain times during the day for the day's events to line up with.</li>
 
-			    <li><b>Day</b> - Presents an entire day's worth of data in a high-detail display.  For each day with data in the objectsource, the calendar will display the day in full-width, with the day's events listed chronologically from top to bottom.</li>
+				<li><b>Day</b> - Presents an entire day's worth of data in a high-detail display.  For each day with data in the objectsource, the calendar will display the day in full-width, with the day's events listed chronologically from top to bottom.</li>
 
 			</ul>
 
@@ -308,9 +275,9 @@ vbox1 "widget/vbox"
 			<property name="height" type="integer">The height of the calendar, in pixels.  If not specified, the calendar may grow vertically an indefinite amount in order to display its given data.  If specified, however, the calendar will be limited to that size.</property>
 
 			<property name="minpriority" type="integer">The minimum priority level for events that will be displayed on the calendar; the values for this integer depend on the nature of the 'priority' field in the data source; only events with priority values numerically higher than or equal to this minimum priority will be displayed.  Defaults to 0.</property>
-			
+
 			<property name="textcolor" type="string">The color of the words in the calendar.</property>
-			
+
 			<property name="width" type="integer">The width of the calendar, in pixels.</property>
 
 			<property name="x" type="integer">X-coordinate of the upper left corner of the calendar, default is 0.</property>
@@ -319,16 +286,12 @@ vbox1 "widget/vbox"
 
 		</properties>
 
-		<children>
-
-		</children>
-
 		<events>
-		
+
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
 			<event name="MouseMove">This event occurs when the user moves the mouse pointer while it is over the widget.  The event will repeatedly fire each time the pointer moves.</event>
-		
+
 			<event name="MouseOut">This event occurs when the user moves the mouse pointer off of the widget.</event>
 
 			<event name="MouseOver">This event occurs when the user first moves the mouse pointer over the widget.  It will not occur again until the user moves the mouse off of the widget and then back over it again.</event>
@@ -337,62 +300,72 @@ vbox1 "widget/vbox"
 
 		</events>
 
-		<actions>
-
-		</actions>
-
-		<clientprops>
-
-		</clientprops>
-
-		<sample>
-
-		<![CDATA[
-
-		]]>
-
-		</sample>
-
 	</widget>
 
+
 	<widget name="chart" type="widget/chart" description="Chart widget for graphing data from an ObjectSource, using the ChartJS library." visual="yes" formelement="no" container="no">
+
 		<overview>
-			<p>A chart widget is used to display charts and graphs of data. It uses the Chart.js library.</p>
+
+			<p>A chart widget is used to display charts and graphs of data.  It uses the Chart.js library.</p>
+
 		</overview>
 
 		<usage>
+
 			<p>The chart widget can be placed inside of any visual container, and will attach itself to any objectsource widget that contains it (whether directly or indirectly).  Charts may not contain visual widgets.</p>
+
 		</usage>
 
 		<properties>
-			<property name="chart_type" type="string">Currently supported types are "bar", "line", "scatter", and "pie". Defaults to "bar". Chart.js supports much more than this, so new types could be added with relative ease.</property>
-			<property name="legend_position" type="string">The position of the legend on the chart. May be "top", "botton", "left", or "right".</property>
-			<property name="objectsource" type="string">The name of the ObjectSource widget which will supply data for the chart. We recommend that you do not specify this directly but instead embed the chart widget within a parent ObjectSource, directly or indirectly. If not specified, the chart will look for an ObjectSource in its parents.</property>
-			<property name="start_at_zero" type="boolean">Set to false if you want the y axis to start at the lowest data value. Default is true.</property>
-			<property name="title" type="string">The title of the chart. Default is none.</property>
+
+			<property name="chart_type" type="string">Currently supported types are "bar", "line", "scatter", and "pie".  Defaults to "bar".  Chart.js supports much more than this, so new types could be added with relative ease.</property>
+
+			<property name="legend_position" type="string">The position of the legend on the chart.  May be "top", "botton", "left", or "right".</property>
+
+			<property name="objectsource" type="string">The name of the ObjectSource widget which will supply data for the chart.  We recommend that you do not specify this directly but instead embed the chart widget within a parent ObjectSource, directly or indirectly.  If not specified, the chart will look for an ObjectSource in its parents.</property>
+
+			<property name="start_at_zero" type="boolean">Set to false if you want the y axis to start at the lowest data value.  Default is true.</property>
+
+			<property name="title" type="string">The title of the chart.  Default is none.</property>
+
 			<property name="titlecolor" type="string">A color, RGB or named, of the chart title.</property>
+
 			<property name="title_size" type="integer">The size, in points, of the title font.</property>
+
 		</properties>
 
 		<children>
+
 			<child type="widget/chart-series">
-				<childproperty name="chart_type" type="string">Chart.js has limited support for having multiple chart types on the same axes. The outer chart type must still be specified if this is set.</childproperty>
+
+				<childproperty name="chart_type" type="string">Chart.js has limited support for having multiple chart types on the same axes.  The outer chart type must still be specified if this is set.</childproperty>
+
 				<childproperty name="color" type="string">A color, RGB or named, for the chart element (ex: line) which represents this series.</childproperty>
-				<childproperty name="fill" type="boolean">Set to false to remove the color fill beneath a line chart. Default is true.</childproperty>
+
+				<childproperty name="fill" type="boolean">Set to false to remove the color fill beneath a line chart.  Default is true.</childproperty>
+
 				<childproperty name="label" type="string">A label for the data series.</childproperty>
+
 				<childproperty name="x_column" type="string">Which column in the data should be used for the x axis? By default, the chart will pick one for you.</childproperty>
+
 				<childproperty name="y_column" type="string">Which column in the data should be used for the y axis? By default, the chart will pick one for you.</childproperty>
+
 			</child>
 
 			<child type="widget/chart-axis">
-				<childproperty name="axis" type="string">Which axis is this? Possible values are "x" and "y". Default is "x".</childproperty>
-				<childproperty name="label" type="string">A label for the axis. Default is none.</childproperty>
+
+				<childproperty name="axis" type="string">Which axis is this? Possible values are "x" and "y".  Default is "x".</childproperty>
+
+				<childproperty name="label" type="string">A label for the axis.  Default is none.</childproperty>
+
 			</child>
+
 		</children>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 // Here is a simple chart.
@@ -419,10 +392,11 @@ chart "widget/chart"
 	x_axis "widget/chart-axis" { axis="x"; label="X"; }
 	}
 
-		]]>
+			]]>
 
 		</sample>
 	</widget>
+
 
 	<widget name="checkbox" type="widget/checkbox" description="Form element capable of selecting an on/off, yes/no, true/false, etc., type of value, via a visual 'check mark'." visual="yes" formelement="yes" container="no">
 
@@ -441,26 +415,22 @@ chart "widget/chart"
 		<properties>
 
 			<property name="checked" type="yes/no">Whether this checkbox should be initially checked or not.  Default 'no'.</property>
-			
+
 			<property name="enabled" type="boolean">This allows the checkbox to be changed.</property>
 
 			<property name="fieldname" type="string">Name of objectsource field that should be associated with this checkbox.</property>
 
 			<property name="form" type="string">The name of the form that this checkbox is associated with.</property>
-			
+
 			<property name="x" type="integer">X-coordinate of the upper left corner of the checkbox, default is 0.</property>
 
 			<property name="y" type="integer">Y-coordinate of the upper left corner of the checkbox, default is 0.</property>
 
 		</properties>
 
-		<children>
-
-		</children>
-
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the checkbox. No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the checkbox.  No parameters are available from this event.</event>
 
 			<event name="DataChange">This event occurs when the user has modified the data value of the checkbox (clicked or unclicked it).</event>
 
@@ -477,18 +447,14 @@ chart "widget/chart"
 		</events>
 
 		<actions>
-		
+
 			<action name="SetValue">This takes a given value and sets the check box value to it.</action>
 
 		</actions>
 
-		<clientprops>
-
-		</clientprops>
-
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -518,12 +484,13 @@ checkbox_test "widget/page"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
-	
+
+
 	<widget name="childwindow" type="widget/childwindow" visual="yes" formelement="no" container="yes" osrcclient="no" description="A dialog or application window which is a lightweight movable container.">
 
 		<overview>
@@ -544,82 +511,62 @@ checkbox_test "widget/page"
 
 		<properties>
 
-		    <property name="background" type="string" subtype="image">A background image for the body of the window.</property>
+			<property name="background" type="string" subtype="image">A background image for the body of the window.</property>
 
-		    <property name="bgcolor" type="string" subtype="color">A color, RGB or named, to be used as the window body's background.If neither transparent.</property>
-						
+			<property name="bgcolor" type="string" subtype="color">A color, RGB or named, to be used as the window body's background.If neither transparent.</property>
+
 			<property name="border_color" type="string">A color that outlines window.</property>
-			
+
 			<property name="border_radius" type="integer">A radius that describes the sharpness of the corners of the window (smaller means sharper).</property>
 
 			<property name="border_style" type="string">Determines the look of the outline.</property>
-			
+
 			<property name="closetype" type="string">Decides wither the screen closes widthwise (1) or heightwise (2).</property>
-			
+
 			<property name="gshade" type="string">Acts as a boolean to declare if the window is shaded or not (all but title bar minimized).</property>
 
-		    <property name="hdr_background" type="string" subtype="color">A background image for the titlebar of the window.</property>
+			<property name="hdr_background" type="string" subtype="color">A background image for the titlebar of the window.</property>
 
-		    <property name="hdr_bgcolor" type="string" subtype="color">A color, RGB or named, for the titlebar of the window.</property>
+			<property name="hdr_bgcolor" type="string" subtype="color">A color, RGB or named, for the titlebar of the window.</property>
 
-		    <property name="height" type="integer">Height, in pixels, of the window.</property>
+			<property name="height" type="integer">Height, in pixels, of the window.</property>
 
-		    <property name="icon" type="string">A pathname to an icon to be used in the upper left corner of the window.  If unspecified, the default "CX" ichthus icon is used instead.</property>
+			<property name="icon" type="string">A pathname to an icon to be used in the upper left corner of the window.  If unspecified, the default "CX" ichthus icon is used instead.</property>
 
-		    <property name="modal" type="yes/no">If "yes", the window is modal (and IsModal need not be passed to "Open").  A modal window will force the user to close the window before anything else in the application can be accessed.</property>
-			
+			<property name="modal" type="yes/no">If "yes", the window is modal (and IsModal need not be passed to "Open").  A modal window will force the user to close the window before anything else in the application can be accessed.</property>
+
 			<property name="shadow_angle" type="integer">The placement of the shadow described as a rotational transformation with respect to the window.</property>
-			
+
 			<property name="shadow_color" type="string">The color of the shadow.</property>
 
 			<property name="shadow_radius" type="integer">A radius that describes the sharpness of the corners of the shadow (smaller means sharper).</property>
 
 			<property name="shadow_offset" type="integer">The placement of the shadow with respect to the window.</property>
 
-		    <property name="style" type="string">Either "dialog" or "window", and determines the style of the window's border.</property>
+			<property name="style" type="string">Either "dialog" or "window", and determines the style of the window's border.</property>
 
-		    <property name="textcolor" type="string" subtype="color">The color for the titlebar's text (window title).  Default "black".</property>
+			<property name="textcolor" type="string" subtype="color">The color for the titlebar's text (window title).  Default "black".</property>
 
-		    <property name="title" type="string">The window's title.</property>
+			<property name="title" type="string">The window's title.</property>
 
-		    <property name="titlebar" type="yes/no">Whether the window will have a titlebar (and the close "X" in the upper right corner of the window). Default "yes".</property>
-			
-		    <property name="toplevel" type="yes/no">If "yes", the window will float above all other widgets in the application, otherwise it will be clipped by its own container.</property>
+			<property name="titlebar" type="yes/no">Whether the window will have a titlebar (and the close "X" in the upper right corner of the window).  Default "yes".</property>
 
-		    <property name="visible" type="boolean">The window is initially visible on screen. The window has an action which can "true".</property>
+			<property name="toplevel" type="yes/no">If "yes", the window will float above all other widgets in the application, otherwise it will be clipped by its own container.</property>
 
-		    <property name="width" type="integer">Width, in pixels, of the window.</property>
+			<property name="visible" type="boolean">The window is initially visible on screen.  The window has an action which can "true".</property>
 
-		    <property name="x" type="integer">X-coordinate of the upper left corner of the window, relative to its container.</property>
+			<property name="width" type="integer">Width, in pixels, of the window.</property>
 
-		    <property name="y" type="integer">Y-coordinate of the upper left corner of the window, relative to its container.</property>
+			<property name="x" type="integer">X-coordinate of the upper left corner of the window, relative to its container.</property>
+
+			<property name="y" type="integer">Y-coordinate of the upper left corner of the window, relative to its container.</property>
 
 		</properties>
-
-		<actions>
-
-		    <action name="Close">Closes the window.  Note that widgets inside the window may choose to veto the Close operation: for example, if there is unsaved data in a form.</action>
-
-		    <action name="Open">Opens the window.  If the parameter IsModal is set to 1, then the window becomes modal (only the window's contents are accessible to the user until the window is closed).  If the parameter NoClose is set to 1, then the close button in the upper right corner of the window becomes inactive and the window will only close via the Close, SetVisibility, and ToggleVisibility actions.</action>
-			
-			<action name="Point">Makes the window relocate to a side using a triangle (pop over).</action>
-
-			<action name="Popup">Opens a window like a pop-up.</action>
-			
-			<action name="SetVisibility">One parameter, "is_visible", which is set to 0 or 1 to hide or show the window, respectively.</action>
-
-			<action name="Shade">Turns the gshade property(see above) on.</action>
-		
-		    <action name="ToggleVisibility">If the window is visible, this closes it.  If it is closed, this opens it.</action>
-
-			<action name="Unshade">Turns the gshade property(see above) off.</action>
-
-		</actions>
 
 		<events>
 
 			<event name="Close">This event is triggered each time the window is closed (becomes invisible).</event>
-			
+
 			<event name="Load">This event is triggered the first time the window is opened.  If the window is visible by default, then this event is triggered when the application loads.</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the checkbox.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the checkbox for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
@@ -634,12 +581,31 @@ checkbox_test "widget/page"
 
 			<event name="Open">This event is triggered each time the window is opened (becomes visible).</event>
 
-
 		</events>
+
+		<actions>
+
+			<action name="Close">Closes the window.  Note that widgets inside the window may choose to veto the Close operation: for example, if there is unsaved data in a form.</action>
+
+			<action name="Open">Opens the window.  If the parameter IsModal is set to 1, then the window becomes modal (only the window's contents are accessible to the user until the window is closed).  If the parameter NoClose is set to 1, then the close button in the upper right corner of the window becomes inactive and the window will only close via the Close, SetVisibility, and ToggleVisibility actions.</action>
+
+			<action name="Point">Makes the window relocate to a side using a triangle (pop over).</action>
+
+			<action name="Popup">Opens a window like a pop-up.</action>
+
+			<action name="SetVisibility">One parameter, "is_visible", which is set to 0 or 1 to hide or show the window, respectively.</action>
+
+			<action name="Shade">Turns the gshade property(see above) on.</action>
+
+			<action name="ToggleVisibility">If the window is visible, this closes it.  If it is closed, this opens it.</action>
+
+			<action name="Unshade">Turns the gshade property(see above) off.</action>
+
+		</actions>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -663,11 +629,12 @@ MyWindow "widget/childwindow"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
+
 
 	<widget name="clock" type="widget/clock" description="A simple clock widget which displays the current time on the client." visual="yes" formelement="no" container="no">
 
@@ -690,9 +657,9 @@ MyWindow "widget/childwindow"
 			<property name="background" type="string">An image for the background of the clock widget.  Should be an ObjectSystem path.</property>
 
 			<property name="bgcolor" type="string">A color, either named or numeric, for the background of the clock.  If neither bgcolor nor background are specified, the clock is transparent.</property>
-			
+
 			<property name="bold" type="string">Acts as a boolean to declare if the type will be bold (larger and thicker).</property>
-			
+
 			<property name="fgcolor1" type="string">A color, either named or numeric, for the foreground text of the clock.</property>
 
 			<property name="fgcolor2" type="string">A color, either named or numeric, for the foreground text's shadow, if 'shadowed' is enabled.</property>
@@ -702,9 +669,9 @@ MyWindow "widget/childwindow"
 			<property name="height" type="integer">The height of the clock, in pixels.</property>
 
 			<property name="hrtype" type="integer">Set to 12 for a 12-hour clock, or to 24 for military (24-hour) time.</property>
-			
+
 			<property name="moveable" type="string">Acts as a boolean to control if the entire clock can be moved.</property>
-			
+
 			<property name="seconds" type="integer">Whether or not the seconds should be displayed.  Default is 'yes'.</property>
 
 			<property name="shadowed" type="yes/no">Whether or not the clock's text has a shadow.  Default is 'no'.</property>
@@ -739,11 +706,12 @@ MyWindow "widget/childwindow"
 
 	</widget>
 
+
 	<widget name="component" type="widget/component" description="A widget which instantiates a custom component" visual="yes" formelement="no" container="no" osrcclient="no">
 
 		<overview>
 
-			<p>This widget is used to instantiate a custom component that has already been defined using a widget/component-decl widget, typically inside a ".cmp" file.  The instantiation can be either static or dynamic:  a static component is rendered along with the component or application that it resides inside, whereas a dynamic component is loaded as needed from the client.  Components may also allow multiple instantiation when dynamic, which is especially beneficial with components whose top-level widget happens to be a widget/childwindow.</p>
+			<p>This widget is used to instantiate a custom component that has already been defined using a widget/component-decl widget, typically inside a ".cmp" file.  The instantiation can be either static or dynamic: a static component is rendered along with the component or application that it resides inside, whereas a dynamic component is loaded as needed from the client.  Components may also allow multiple instantiation when dynamic, which is especially beneficial with components whose top-level widget happens to be a widget/childwindow.</p>
 
 		</overview>
 
@@ -766,8 +734,8 @@ MyWindow "widget/childwindow"
 			<property name="mode" type="string">Either "static" or "dynamic".  A static component is rendered with the application, whereas a dynamic one is loaded as needed from the client.  Defaults to 'static'.</property>
 
 			<property name="multiple_instantiation" type="yes/no">If enabled (dynamic components only), the component can be instantiated more than once on the client.  Defaults to 'no'.</property>
-		
-			<property name="path" type="string">The path, in the OSML, to the component's definition (.cmp) file. (e.g. /sys/cmp/smart_field.cmp, /sys/cmp/form_controls.cmp, /samples/button.cmp).</property>
+
+			<property name="path" type="string">The path, in the OSML, to the component's definition (.cmp) file.  (e.g. /sys/cmp/smart_field.cmp, /sys/cmp/form_controls.cmp, /samples/button.cmp).</property>
 
 			<property name="toplevel" type="string">Acts as a boolean to indicate if there are any components on a higher level.</property>
 
@@ -781,13 +749,33 @@ MyWindow "widget/childwindow"
 
 		</properties>
 
-		<actions>
+		<children>
 
-			<action name="Destroy">Destroys the component.  If multiple instances exist, then all instances are destroyed.</action>
+			<child type="/sys/cmp/smart_field.cmp">
 
-			<action name="Instantiate">Instantiates the component.</action>
+				<childproperty name="ctl_type" type="string"> Type of smart field (e.g. label, editbox, checkbox, datetime).</childproperty>
 
-		</actions>
+				<childproperty name="type" type="string">(e.g. readonly).  Must have field be set in order to be "readonly".</childproperty>
+
+				<childproperty name="value" type="string">This is something which can accessed as :this_widget:value (returns the value of text which can't be directly accessed?), but can not be set directly through this property -- see SetValue listed under the Action section.</childproperty>
+
+			</child>
+
+			<child type="/sys/cmp/form_controls.cmp">
+
+				<childproperty name="multienter" type="integer">(e.g. 1)</childproperty>
+
+				<childproperty name="object_name" type="string">Title to put across the form control bar (Note: the form_controls.cmp allows the user to perform row operations on a given record set).</childproperty>
+
+			</child>
+
+			<child type="/apps/kardia/modules/base/editbox_tree.cmp">
+
+				<childproperty name="content" type="string">This is something which can accessed as :this_widget:content (returns the value of text which can't be directly accessed?), but can not be set directly through this property -- see SetValue listed under the Action section.</childproperty>
+
+			</child>
+
+		</children>
 
 		<events>
 
@@ -795,33 +783,13 @@ MyWindow "widget/childwindow"
 
 		</events>
 
-		<children>
+		<actions>
 
-		    <child type="/sys/cmp/smart_field.cmp">
+			<action name="Destroy">Destroys the component.  If multiple instances exist, then all instances are destroyed.</action>
 
-			    <childproperty name="ctl_type" type="string"> Type of smart field (e.g. label, editbox, checkbox, datetime).</childproperty>
+			<action name="Instantiate">Instantiates the component.</action>
 
-				<childproperty name="type" type="string">(e.g. readonly). Must have field be set in order to be "readonly".</childproperty>
-
-				<childproperty name="value" type="string">This is something which can accessed as :this_widget:value (returns the value of text which can't be directly accessed?), but can not be set directly through this property -- see SetValue listed under the Action section.</childproperty>
-
-		    </child>
-
-		    <child type="/sys/cmp/form_controls.cmp">
-
-			    <childproperty name="multienter" type="integer">(e.g. 1)</childproperty>
-
-			    <childproperty name="object_name" type="string">Title to put across the form control bar (Note: the form_controls.cmp allows the user to perform row operations on a given record set).</childproperty>
-
-		    </child>
-
-		    <child type="/apps/kardia/modules/base/editbox_tree.cmp">
-
-			    <childproperty name="content" type="string">This is something which can accessed as :this_widget:content (returns the value of text which can't be directly accessed?), but can not be set directly through this property -- see SetValue listed under the Action section.</childproperty>
-
-		    </child>
-
-		</children>
+		</actions>
 
 		<sample>
 
@@ -848,6 +816,7 @@ formctl "widget/component"
 		</sample>
 
 	</widget>
+
 
 	<widget name="component-decl" type="widget/component-decl" description="A widget which defines a custom component" visual="yes" formelement="no" container="yes" osrcclient="no">
 
@@ -886,23 +855,22 @@ formctl "widget/component"
 			<property name="visual" type="string">Indicates if the component is seen (not = -1).</property>
 
 		</properties>
-		
-		
+
+		<events>
+
+			<event name="LoadComplete">Occurs when the widget has finished launching.</event>
+
+		</events>
+
 		<actions>
 
 			<action name="Alert">Sends an alert to the screen.</action>
-		
+
 			<action name="Launch">Loads the widget.</action>
-			
+
 			<action name="TriggerEvent">Allows events to happen.</action>
-			
+
 		</actions>
-		
-		<events>
-		
-			<event name="LoadComplete">Occurs when the widget has finished launching.</event>
-		
-		</events>
 
 		<sample>
 
@@ -956,11 +924,12 @@ my_button "widget/component-decl"
 
 	</widget>
 
+
 	<widget name="connector" type="widget/connector" description="A nonvisual widget used to trigger an Action on a widget when an Event on another widget fires." visual="no" formelement="no" container="no">
 
 		<overview>
 
-			<p>Each widget can have events and actions associated with it. The events occur when certain things occur via the user interface, via timers, or even as a result of data being loaded from the server.  Actions cause certain things to happen to or within a certain widget, for example causing an HTML layer to reload with a new page, or causing a scrollable area to scroll up or down.</p>
+			<p>Each widget can have events and actions associated with it.  The events occur when certain things occur via the user interface, via timers, or even as a result of data being loaded from the server.  Actions cause certain things to happen to or within a certain widget, for example causing an HTML layer to reload with a new page, or causing a scrollable area to scroll up or down.</p>
 
 			<p>The connector widget allows an event to be linked with an action without actually writing any JavaScript code to do so -- the connector object is created, and given an event to trigger it and an action to perform when it is triggered.</p>
 
@@ -980,31 +949,23 @@ my_button "widget/component-decl"
 
 		<properties>
 
-		    <property name="action" type="string" subtype="widgetaction">The name of the action which will be activated on another widget on the page.</property>
+			<property name="action" type="string" subtype="widgetaction">The name of the action which will be activated on another widget on the page.</property>
 
-		    <property name="event" type="string" subtype="widgetevent">The name of the event that this connector will act on.</property>
-			
-		    <property name="source" type="string" subtype="widget">The name of the widget generating the event (defaults to the widget the connector is placed inside of).</property>
+			<property name="event" type="string" subtype="widgetevent">The name of the event that this connector will act on.</property>
 
-		    <property name="target" type="string" subtype="widget">The name of another widget on the page whose action will be called by this connector (if unspecified, defaults to the widget the connector is placed inside of).</property>
+			<property name="source" type="string" subtype="widget">The name of the widget generating the event (defaults to the widget the connector is placed inside of).</property>
+
+			<property name="target" type="string" subtype="widget">The name of another widget on the page whose action will be called by this connector (if unspecified, defaults to the widget the connector is placed inside of).</property>
 
 		</properties>
-		
-		<!--<events>
-		
-		</events>
-		
-		<actions>
-		
-		</actions>-->
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
-// Here's our connector. Imagine that this is embedded within a treeview
+// Here's our connector.  Imagine that this is embedded within a treeview
 
 // and references an 'html' control called 'ht1' somewhere else on the page.
 
@@ -1030,23 +991,24 @@ cn1 "widget/connector"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="datetime" type="widget/datetime" description="A visual widget for displaying and editing a date/time type value." visual="yes" formelement="yes" container="no">
 
 		<overview>
 
-		    <p>The datetime widget displays a calendar and clock.  Input is done by typing into the bar or by selecting a date in display pane.  When the form goes into query mode two panes will appear, one for the start and one for the end time.  Note that the osml format for searching for dates is dd Mon yyyy, whereas the format dates are displayed in the widget is Mon dd, yyyy.</p>
+			<p>The datetime widget displays a calendar and clock.  Input is done by typing into the bar or by selecting a date in display pane.  When the form goes into query mode two panes will appear, one for the start and one for the end time.  Note that the osml format for searching for dates is dd Mon yyyy, whereas the format dates are displayed in the widget is Mon dd, yyyy.</p>
 
 		</overview>
 
 		<usage>
 
-		    <p>This widget can be placed within any visual widget.</p>
+			<p>This widget can be placed within any visual widget.</p>
 
 		</usage>
 
@@ -1059,7 +1021,7 @@ cn1 "widget/connector"
 			<property name="default_time" type="string">When the user sets the date without selecting a time value (or if date_only is set), use this time as the "default" time.  This can be set to "00:00:00" or "23:59:59", for example, to specify a time at the start or end of a day.</property>
 
 			<property name="fgcolor" type="string">The foreground color of the bar and pane (named or numeric).</property>
-			
+
 			<property name="fieldname" type="string">Not used currently to my knowledge.</property>
 
 			<property name="form" type="string">Name of a form object that is a parent of the datetime widget (not required).</property>
@@ -1082,7 +1044,7 @@ cn1 "widget/connector"
 
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the widget. No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the widget.  No parameters are available from this event.</event>
 
 			<event name="DataChange">This event occurs when the user has modified the data value of the widget (clicked or unclicked it).</event>
 
@@ -1101,16 +1063,16 @@ cn1 "widget/connector"
 			<event name="MouseUp">This event occurs when the user releases the mouse button on the widget.</event>
 
 		</events>
-		
+
 		<actions>
-		
+
 			<action name="SetValue">Generates an internal data object using the data specified or the current time.</action>
-		
+
 		</actions>
 
 		<sample>
 
-	<![CDATA[
+			<![CDATA[
 
 	dda "widget/datetime" {
 
@@ -1128,23 +1090,24 @@ cn1 "widget/connector"
 
 	}
 
-	]]>
+			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="dropdown" type="widget/dropdown" description="A visual widget which allows the user to select one from a number of options in a list which appears when the user clicks on the widget." visual="yes" formelement="yes" container="no">
 
 		<overview>
 
-		  <p>A dropdown form element widget that allows one of several options to be selected in a visual manner.  The options are filled in using one of the child widgets, or via an SQL query to a database defined below.</p>
+			<p>A dropdown form element widget that allows one of several options to be selected in a visual manner.  The options are filled in using one of the child widgets, or via an SQL query to a database defined below.</p>
 
 		</overview>
 
 		<usage>
 
-		  <p>This widget can be placed within any visual widget (or within a form widget).  It may only contain 'dropdownitem' child objects, although it may of course also contain connectors as needed.</p>
+			<p>This widget can be placed within any visual widget (or within a form widget).  It may only contain 'dropdownitem' child objects, although it may of course also contain connectors as needed.</p>
 
 		</usage>
 
@@ -1155,24 +1118,24 @@ cn1 "widget/connector"
 			<property name="fieldname" type="string">Fieldname (from the dataset) to bind this element to.</property>
 
 			<property name="form" type="string">Represents the widget form (groups many widgets into one widget).</property>
-			
+
 			<property name="height" type="integer">Height, in pixels, of the dropdown.</property>
-			
+
 			<property name="hilight" type="integer">The color of the highlighted option when the mouse goes over the item.</property>
 
 			<property name="invalid_select_default" type="integer">The default widget that has focus when the dropdown is first activated.</property>
-			
+
 			<property name="mode" type="string">If this is set to objectsource then the dropdown acts an objectsource client.</property>
 
 			<property name="num_disp" type="integer">Number of widgets displayed at once in the dropdown box.</property>
-			
+
 			<property name="objectsource" type="string">Represents the widget object source (transfers data to and from server).</property>
-			
+
 			<property name="popup_width" type="integer">Width of popup dropdown list.</property>
-			
+
 			<property name="query_multiselect" type="yes/no">If set to yes, this indicates that when the dropdown's form is in search (QBF) mode, the dropdown will allow multiple items to be selected, so the user can search for records/objects that match one of several values.  The values will be listed in the dropdown, separated by commas.</property>
 
-			<property name="sql" type="string">The SQL used to retrieve the list of items for the dropdown.  It should have between two and five columns, in this order:  label, value, selected (0 or 1, whether the item is selected by default), grp (group name), hidden (0 or 1 to hide the item from the dropdown list but still allow it to be a valid value).</property>
+			<property name="sql" type="string">The SQL used to retrieve the list of items for the dropdown.  It should have between two and five columns, in this order: label, value, selected (0 or 1, whether the item is selected by default), grp (group name), hidden (0 or 1 to hide the item from the dropdown list but still allow it to be a valid value).</property>
 
 			<property name="width" type="integer">Width, in pixels, of the dropdown.</property>
 
@@ -1197,11 +1160,11 @@ cn1 "widget/connector"
 		<events>
 
 			<event name="DataChange">This event occurs when the user has modified the data value of the widget (clicked or unclicked it).</event>
-			
+
 			<event name="DataModify">This event occurs when the data is changed (occurs when key press or button changes things).</event>
 
 			<event name="GetFocus">This event occurs when the edit bar receives keyboard focus (if the user tabs on to it or clicks on it, for instance).</event>
-			
+
 			<event name="LoseFocus">This event occurs when the edit bar of the dropdown loses keyboard focus (if the user tabs off of it, for instance).</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
@@ -1221,18 +1184,18 @@ cn1 "widget/connector"
 		<actions>
 
 			<action name="ClearItems">Deletes all the widgets in the dropdown menu.</action>
-			
+
 			<action name="SetGroup">This causes the dropdown to display a different Group of items (use the Group parameter).  It can also restrict what items are displayed based on a minimum or maximum value (use Min and Max parameters).</action>
 
 			<action name="SetItems">This specifies a SQL (use "SQL" parameter) query to use to re-load the contents of the dropdown.  It should have between two and five columns, in this order: label, value, selected (0 or 1, whether the item is selected by default), grp (group name), hidden (0 or 1 to hide the item from the dropdown list but still allow it to be a valid value).</action>
 
 			<action name="SetValue">Changes the child property "value".</action>
-			
+
 		</actions>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -1300,11 +1263,12 @@ myDropDown2 "widget/dropdown"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
+
 
 	<widget name="editbox" type="widget/editbox" description="A visual widget which allows the entry of one line of textual data." visual="yes" formelement="yes" container="no">
 
@@ -1312,7 +1276,7 @@ myDropDown2 "widget/dropdown"
 
 			<p>An editbox form element widget allows the display and data entry of a single line of text (or a numeric value).  When the editbox is clicked (and thus receives keyboard focus), the user can type and erase data inside the widget.  Data which does not fit will cause the text to scroll.  When it receives keyboard focus, the editbox displays a flashing I-beam cursor.  The cursor color uses the data focus color for the page (default is '#000080', or dark blue).</p>
 
-			<p>  When an editbox is part of a form and the form goes into query mode the editbox has several additional features.  First, you can use the * operator as a wildcard (e.g. *ber matches September, October, November, December).  Second you can enter a range if the field is numeric (e.g. 1-100).  Thirdly, a list of criteria can be specified, separated by commas.</p>
+			<p> When an editbox is part of a form and the form goes into query mode the editbox has several additional features.  First, you can use the * operator as a wildcard (e.g. *ber matches September, October, November, December).  Second you can enter a range if the field is numeric (e.g. 1-100).  Thirdly, a list of criteria can be specified, separated by commas.</p>
 
 		</overview>
 
@@ -1326,10 +1290,10 @@ myDropDown2 "widget/dropdown"
 
 			<property name="background" type="string">A background image for the contents of the editbox.</property>
 
-			<property name="bgcolor" type="string">A color, RGB or named, for the editbox contents. If neither bgcolor nor background is specified, the editbox is transparent.</property>
+			<property name="bgcolor" type="string">A color, RGB or named, for the editbox contents.  If neither bgcolor nor background is specified, the editbox is transparent.</property>
 
 			<property name="description_fgcolor" type="string">A color, RGB or named, editbox's value description.  The value description is displayed to the right of the value in the editbox, in parentheses, and in a different color.</property>
-			
+
 			<property name="disabled" type="boolean">Specifies wither the edit box can be written in, default is true meaning the edit box cannot be written in.</property>
 
 			<property name="empty_description" type="string">The value description to display in the editbox when the editbox is empty.  For instance, "optional" or "required" or "type search and press ENTER" might be commonly used empty_description settings.</property>
@@ -1354,17 +1318,13 @@ myDropDown2 "widget/dropdown"
 
 		</properties>
 
-		<!--<children>
-
-		</children>-->
-
 		<events>
-			
+
 			<event name="BeforeDataChange">This event occurs before the data changes and can stop the data change event.</event>
-			
+
 			<event name="BeforeKeyPress">This event occurs before the key press event is fired and can stop the key press event.</event>
-			
-			<event name="Click">This event occurs when the user clicks the widget. No parameters are available from this event.</event>
+
+			<event name="Click">This event occurs when the user clicks the widget.  No parameters are available from this event.</event>
 
 			<event name="DataChange">This event occurs when the user has modified the data value of the widget (clicked or unclicked it).</event>
 
@@ -1375,7 +1335,7 @@ myDropDown2 "widget/dropdown"
 			<event name="GetFocus">This event occurs when the editbox receives keyboard focus (if the user tabs on to it or clicks on it, for instance).</event>
 
 			<event name="KeyPress">This event occurs when the user presses any key.</event>
-			
+
 			<event name="LoseFocus">This event occurs when the editbox loses keyboard focus (if the user tabs off of it, for instance).</event>
 
 			<event name="MouseUp">This event occurs when the user releases the mouse button on the widget.</event>
@@ -1387,17 +1347,17 @@ myDropDown2 "widget/dropdown"
 			<event name="MouseOut">This event occurs when the user moves the mouse pointer off of the widget.</event>
 
 			<event name="MouseMove">This event occurs when the user moves the mouse pointer while it is over the widget.  The event will repeatedly fire each time the pointer moves.</event>
-			
+
 			<event name="ReturnPressed">This event occurs when the user presses the return key.</event>
-			
+
 			<event name="TabPressed">This event occurs when the user presses the tab key.</event>
 
 		</events>
 
 		<actions>
-			
+
 			<action name="Enable">The Enable action allows an edit box to be written in, and takes no parameters x from being written in, and takes no parameters.</action>
-			
+
 			<action name="SetFocus">The SetFocus action selects and gives control to an edit box.</action>
 
 			<action name="SetValue">The SetValue action modifies the contents of an editbox, and takes a single parameter, 'Value' (string).</action>
@@ -1408,7 +1368,7 @@ myDropDown2 "widget/dropdown"
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -1434,11 +1394,12 @@ my_editbox "widget/editbox"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
+
 
 	<widget name="execmethod" type="widget/execmethod" visual="no" formelement="no" container="no" description="A nonvisual widget which can call ObjectSystem methods on server objects.">
 
@@ -1452,29 +1413,29 @@ my_editbox "widget/editbox"
 
 		<usage>
 
-			<p>The execmethod widget, since it is nonvisual, can be placed almost anywhere but is typically placed at the top-level (within an object of type "widget/page") for clarity's sake. It has no effect on its container.These widgets cannot contain visual widgets, and since they have no Events, normally contain no connector widgets either.</p>
+			<p>The execmethod widget, since it is nonvisual, can be placed almost anywhere but is typically placed at the top-level (within an object of type "widget/page") for clarity's sake.  It has no effect on its container.These widgets cannot contain visual widgets, and since they have no Events, normally contain no connector widgets either.</p>
 
 		</usage>
 
 		<properties>
 
-		    <property name="method" type="string" subtype="OSMLmethod">The name of the method to invoke.</property>
+			<property name="method" type="string" subtype="OSMLmethod">The name of the method to invoke.</property>
 
-		    <property name="object" type="string" subtype="OSMLobject">The ObjectSystem pathname of the object on which the method is to be run.</property>
+			<property name="object" type="string" subtype="OSMLobject">The ObjectSystem pathname of the object on which the method is to be run.</property>
 
-		    <property name="parameter" type="string">A string parameter to pass to the method being invoked.</property>
+			<property name="parameter" type="string">A string parameter to pass to the method being invoked.</property>
 
 		</properties>
 
 		<actions>
 
-		    <action name="ExecuteMethod">Action causes the widget to execute the method on the server. It can take three parameters, which default to those provided in this widget's properties: "Objname", the object path, "Method", the method to invoke, and "Parameter", the parameter to pass to the method being invoked.</action>
+			<action name="ExecuteMethod">Action causes the widget to execute the method on the server.  It can take three parameters, which default to those provided in this widget's properties: "Objname", the object path, "Method", the method to invoke, and "Parameter", the parameter to pass to the method being invoked.</action>
 
 		</actions>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -1492,33 +1453,28 @@ mySoundPlayer "widget/execmethod"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="form" type="widget/form" visual="no" formelement="no" container="yes" description="A nonvisual container used to group a set of form element widgets into a single record or object">
 
 		<overview>
 
-			<p>The form widget is used as a high-level container for form elements.  Essentially, a form widget represents a single record of data, or the attributes of a single object in the objectsystem (or of a single query result set object). Form widgets must be used in conjunction with an ObjectSource widget, which does the actual transferring of data to and from the server.</p>
+			<p>The form widget is used as a high-level container for form elements.  Essentially, a form widget represents a single record of data, or the attributes of a single object in the objectsystem (or of a single query result set object).  Form widgets must be used in conjunction with an ObjectSource widget, which does the actual transferring of data to and from the server.</p>
 
 			<p>Forms have five different "modes"of operation, each of which can be specifically allowed or disallowed for the form.</p>
 
-		<ol>
-
-		<li> No Data - form inactive/disabled, no data viewed/edited.</li>
-
-		<li> View - data being viewed readonly.</li>
-
-		<li> Modify - existing data being modified.</li>
-
-		<li> Query - query criteria being entered (used for query-by-form applications)</li>
-
-		<li> New - new object being entered/created.</li>
-
-		</ol>
+			<ol>
+				<li> No Data - form inactive/disabled, no data viewed/edited.</li>
+				<li> View - data being viewed readonly.</li>
+				<li> Modify - existing data being modified.</li>
+				<li> Query - query criteria being entered (used for query-by-form applications)</li>
+				<li> New - new object being entered/created.</li>
+			</ol>
 
 			<p>Occasionally, the user may perform an operation which inherently disregards that the form may contain unsaved data.  When this occurs and there is newly created or modified data in the form, the application must ask the user whether the data in the form should be saved or discarded, or whether to simply not even perform the operation in question.  Since DHTML does not inherently have a "three-way confirm" message box (with save, discard, and cancel buttons), Centrallix allows a form to specify a "three-way confirm" window.  This should be a hidden (visible=no) "widget/htmlwindow" object which may contain any content, but should at least contain three buttons named "_3bConfirmSave", "_3bConfirmDiscard", and "_3bConfirmCancel" directly in the htmlwindow.  During a confirm operation, this window will become "application-modal"; that is, no other widgets in the application may be accessed by the user until one of the three buttons is pushed.</p>
 
@@ -1534,134 +1490,47 @@ mySoundPlayer "widget/execmethod"
 
 		<properties>
 
-			<property name="allow_delete" type="yes/no"><ni/>Allow deletion of the displayed record.</property>
+			<property name="allow_delete" type="yes/no"><ni />Allow deletion of the displayed record.</property>
 
-			<property name="allow_modify" type="yes/no"><ni/>Allow modification of existing records.</property>
+			<property name="allow_modify" type="yes/no"><ni />Allow modification of existing records.</property>
 
-			<property name="allow_new" type="yes/no"><ni/>Allow creation of new records.</property>
+			<property name="allow_new" type="yes/no"><ni />Allow creation of new records.</property>
 
-			<property name="allow_nodata" type="yes/no"><ni/>Allow the 'no data' state.</property>
+			<property name="allow_nodata" type="yes/no"><ni />Allow the 'no data' state.</property>
 
-			<property name="allow_obscure" type="yes/no"><ni/>Default "no".  If this is set to "yes", then the form will permit its data to be obscured (hidden from the user, via a window closure or tab page switch) and unsaved at the same time.  If set to "no", the form will require the user to save or cancel any data modifications before the form may be obscured.</property>
+			<property name="allow_obscure" type="yes/no"><ni />Default "no".  If this is set to "yes", then the form will permit its data to be obscured (hidden from the user, via a window closure or tab page switch) and unsaved at the same time.  If set to "no", the form will require the user to save or cancel any data modifications before the form may be obscured.</property>
 
-			<property name="allow_query" type="yes/no"><ni/>Allow query by form.</property>
+			<property name="allow_query" type="yes/no"><ni />Allow query by form.</property>
 
-			<property name="allow_view" type="yes/no"><ni/>Allow viewing of existing data.</property>
+			<property name="allow_view" type="yes/no"><ni />Allow viewing of existing data.</property>
 
-			<property name="auto_focus" type="yes/no"><ni/>Default "yes".  Whether to automatically place the focus on the first form element in the form when the form transitions to the New, Modify, or Search mode for any reason other than the user manually putting focus on one of the form elements.</property>
+			<property name="auto_focus" type="yes/no"><ni />Default "yes".  Whether to automatically place the focus on the first form element in the form when the form transitions to the New, Modify, or Search mode for any reason other than the user manually putting focus on one of the form elements.</property>
 
-			<property name="confirm_delete" type="yes/no"><ni/>Whether to pop up an OK/Cancel message box asking the user whether he/she is sure the record should be deleted.</property>
+			<property name="confirm_delete" type="yes/no"><ni />Whether to pop up an OK/Cancel message box asking the user whether he/she is sure the record should be deleted.</property>
 
 			<property name="comfirm_discard" type="yes/no">Set to true when the discard button of the 3 buttom confirm window (3bconfirmwindow) is pressed.</property>
-			
-			<property name="enter_mode" type="string"><ni/>Can be "save" (default), "nextfield", or "lastsave".  Controls what to do when the user presses ENTER while in a form element in this form.  "save" means to save the record immediately.  "nextfield" means to move to the next form field, as if TAB were pressed instead.  "lastsave" means to move to the next form field, but once ENTER is pressed on the very last field, to then save the record.  Most people prefer "save" for this, since that is consistent with how normal applications work, but people in finance or accounting work often prefer "lastsave" since it allows them to perform high-speed data entry using a numeric keypad.</property>
+
+			<property name="enter_mode" type="string"><ni />Can be "save" (default), "nextfield", or "lastsave".  Controls what to do when the user presses ENTER while in a form element in this form.  "save" means to save the record immediately.  "nextfield" means to move to the next form field, as if TAB were pressed instead.  "lastsave" means to move to the next form field, but once ENTER is pressed on the very last field, to then save the record.  Most people prefer "save" for this, since that is consistent with how normal applications work, but people in finance or accounting work often prefer "lastsave" since it allows them to perform high-speed data entry using a numeric keypad.</property>
 
 			<property name="interlock_with" type="string">Stores wither this form can be grouped with other forms.</property>
-			
-			<property name="MultiEnter" type="integer"><ni/>Enable MultiEnter.</property>
 
-			<property name="next_form" type="string" subtype="widget"><ni/>Specifies another form to transfer focus to when the user presses TAB at the end of the form.</property>
+			<property name="MultiEnter" type="integer"><ni />Enable MultiEnter.</property>
 
-			<property name="next_form_within" type="string" subtype="widget"><ni/>Similar to "next_form", but searches for the next form after this one within a given widget or component.  Transitioning from one component context to another is permitted (you could specify a "widget/page" widget here, and cause focus to transfer to another form in the same application, regardless of level of component nesting; this may or may not be desired behavior).</property>
+			<property name="next_form" type="string" subtype="widget"><ni />Specifies another form to transfer focus to when the user presses TAB at the end of the form.</property>
+
+			<property name="next_form_within" type="string" subtype="widget"><ni />Similar to "next_form", but searches for the next form after this one within a given widget or component.  Transitioning from one component context to another is permitted (you could specify a "widget/page" widget here, and cause focus to transfer to another form in the same application, regardless of level of component nesting; this may or may not be desired behavior).</property>
 
 			<property name="objectsource" type="string">Represents the widget object source (transfers data to and from server).</property>
-			
-			<property name="ReadOnly" type="integer"><ni/>Allow changes.</property>
 
-			<property name="TabMode" type="string"><ni/>How to react to a tab in a control.</property>
+			<property name="ReadOnly" type="integer"><ni />Allow changes.</property>
 
-			<property name="tab_revealed_only" type="yes/no"><ni/>When tabbing between form elements, if this is set to "yes", do not transfer focus to form elements that are not currently visible to the user.</property>
+			<property name="TabMode" type="string"><ni />How to react to a tab in a control.</property>
+
+			<property name="tab_revealed_only" type="yes/no"><ni />When tabbing between form elements, if this is set to "yes", do not transfer focus to form elements that are not currently visible to the user.</property>
 
 			<property name="_3bconfirmwindow" type="string">The name of the window to use for all 3-way confirm operations (save/discard/cancel).</property>
 
 		</properties>
-
-		<children>
-
-			<child type="formelement">
-
-				<childproperty name="fieldname" type="string"><ni/>Fieldname (from the dataset) to bind this element to.</childproperty>
-
-			</child>
-
-			<child type="formstatus">
-
-			</child>
-
-		</children>
-
-		<events>
-
-			<event name="BeforeSave">This event occurs just before the form is enabled after a save.</event>
-			
-			<event name="DataChange">This event occurs when a child controller changes its data.</event>
-			
-			<event name="DataDeleted">This event occurs when the delete function is successfully completed.</event>
-			
-			<event name="DataLoaded">This event occurs when it is confirmed that the method search for object is available.</event>
-			
-			<event name="DataSaved">This event occurs when the save action was successful.</event>
-			
-			<event name="Discard">This event occurs after the discard action is performed.</event>
-			
-			<event name="ModeChange">This event occurs at the end of the change mode action (always with status change event).</event>
-			
-			<event name="Modify">This event occurs if and only if there was a mode change and the new mode is the 'Modify' state (always occurs with both a statusChange event and a ModeChange Event).</event>
-			
-			<event name="New">This event occurs if and only if there was a mode change and the new mode is the 'New' state (always occurs with both a statusChange event and a ModeChange Event).</event>
-			
-			<event name="NoData">This event occurs if and only if there was a mode change and the new mode is the 'NoData' state (always occurs with both a statusChange event and a ModeChange Event.</event>
-			
-			<event name="Query">This event occurs if and only if there was a mode change and the new mode is the 'Query' state (always occurs with both a statusChange event and a ModeChange Event.</event>
-			
-			<event name="StatusChange">The even occurs when the form changes modes or when a child control changes its data.</event>
-			
-			<event name="View">This event occurs if and only if there was a mode change and the new mode is the 'View' state (always occurs with both a statusChange event and a ModeChange Event.</event>
-		
-		</events>
-
-		<actions>
-
-			<action name="Clear"><ni/>Clears the form to a 'no data'state.</action>
-
-			<action name="Delete"><ni/>Deletes the current object displayed.</action>
-
-			<action name="Discard">Cancels an edit of form contents.</action>
-						
-			<action name="Disable">Prevents interaction with the entire form.</action>
-
-			<action name="Edit">Allows editing of form's contents.</action>
-						
-			<action name="Enable">Allows interaction with the form.</action>
-
-			<action name="First">Moves the form to the first object in the objectsource.</action>
-
-			<action name="Last">Moves the form to the last object in the objectsource.</action>
-
-			<action name="New"><ni/>Allows creation of new form contents.</action>
-
-			<action name="Next">Moves the form to the next object in the objectsource.</action>
-
-			<action name="Prev">Moves the form to the previous object in the objectsource.</action>
-
-			<action name="Query">Allows entering of query criteria.</action>
-
-			<action name="QueryExec">the query and returns data.</action>
-						
-			<action name="QueryToggle">Either executes a query or allows one to be made depending on the previous state.</action>
-
-			<action name="Save">Saves the form's contents.</action>
-						
-			<action name="SetValue">Modifies a field and puts the form into a new modify or search mode if appropriate.</action>
-						
-			<action name="Submit">Attemps to save data, if there is an error it returns false.</action>
-			
-			<action name="test3bconfirm">Debugging tool to test the 3bcomfirm method (only use if you know what this method is).</action>
-			
-			<action name="View">Changes the form to view mode.</action>
-
-
-		</actions>
 
 		<clientprops>
 
@@ -1683,9 +1552,95 @@ mySoundPlayer "widget/execmethod"
 
 		</clientprops>
 
+		<children>
+
+			<child type="formelement">
+
+				<childproperty name="fieldname" type="string"><ni />Fieldname (from the dataset) to bind this element to.</childproperty>
+
+			</child>
+
+			<child type="formstatus">
+
+			</child>
+
+		</children>
+
+		<events>
+
+			<event name="BeforeSave">This event occurs just before the form is enabled after a save.</event>
+
+			<event name="DataChange">This event occurs when a child controller changes its data.</event>
+
+			<event name="DataDeleted">This event occurs when the delete function is successfully completed.</event>
+
+			<event name="DataLoaded">This event occurs when it is confirmed that the method search for object is available.</event>
+
+			<event name="DataSaved">This event occurs when the save action was successful.</event>
+
+			<event name="Discard">This event occurs after the discard action is performed.</event>
+
+			<event name="ModeChange">This event occurs at the end of the change mode action (always with status change event).</event>
+
+			<event name="Modify">This event occurs if and only if there was a mode change and the new mode is the 'Modify' state (always occurs with both a statusChange event and a ModeChange Event).</event>
+
+			<event name="New">This event occurs if and only if there was a mode change and the new mode is the 'New' state (always occurs with both a statusChange event and a ModeChange Event).</event>
+
+			<event name="NoData">This event occurs if and only if there was a mode change and the new mode is the 'NoData' state (always occurs with both a statusChange event and a ModeChange Event.</event>
+
+			<event name="Query">This event occurs if and only if there was a mode change and the new mode is the 'Query' state (always occurs with both a statusChange event and a ModeChange Event.</event>
+
+			<event name="StatusChange">The even occurs when the form changes modes or when a child control changes its data.</event>
+
+			<event name="View">This event occurs if and only if there was a mode change and the new mode is the 'View' state (always occurs with both a statusChange event and a ModeChange Event.</event>
+
+		</events>
+
+		<actions>
+
+			<action name="Clear"><ni />Clears the form to a 'no data'state.</action>
+
+			<action name="Delete"><ni />Deletes the current object displayed.</action>
+
+			<action name="Discard">Cancels an edit of form contents.</action>
+
+			<action name="Disable">Prevents interaction with the entire form.</action>
+
+			<action name="Edit">Allows editing of form's contents.</action>
+
+			<action name="Enable">Allows interaction with the form.</action>
+
+			<action name="First">Moves the form to the first object in the objectsource.</action>
+
+			<action name="Last">Moves the form to the last object in the objectsource.</action>
+
+			<action name="New"><ni />Allows creation of new form contents.</action>
+
+			<action name="Next">Moves the form to the next object in the objectsource.</action>
+
+			<action name="Prev">Moves the form to the previous object in the objectsource.</action>
+
+			<action name="Query">Allows entering of query criteria.</action>
+
+			<action name="QueryExec">the query and returns data.</action>
+
+			<action name="QueryToggle">Either executes a query or allows one to be made depending on the previous state.</action>
+
+			<action name="Save">Saves the form's contents.</action>
+
+			<action name="SetValue">Modifies a field and puts the form into a new modify or search mode if appropriate.</action>
+
+			<action name="Submit">Attemps to save data, if there is an error it returns false.</action>
+
+			<action name="test3bconfirm">Debugging tool to test the 3bcomfirm method (only use if you know what this method is).</action>
+
+			<action name="View">Changes the form to view mode.</action>
+
+		</actions>
+
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 form1 "widget/form"
 
@@ -1695,17 +1650,18 @@ form1 "widget/form"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="formstatus" type="widget/formstatus" visual="yes" formelement="no" container="no" description="A specialized visual widget used to display the current mode of a form widget.">
 
 		<overview>
 
-			<p>Many times with multi-mode forms like those offered by Centrallix, the end-user can become confused as to what the form is currently "doing" (for instance, is a blank form with a blinking cursor in a "new" state or "enter query" state?).  Centrallix helps to address this issue using the form status widget. A form status widget displays the current mode of operation that a form is in, as well as whether the form is busy processing a query, save, or delete operation.  This clear presentation of the form's mode is intended to clear up any confusion created by a multi-mode form.  This widget is a special-case form element.</p>
+			<p>Many times with multi-mode forms like those offered by Centrallix, the end-user can become confused as to what the form is currently "doing" (for instance, is a blank form with a blinking cursor in a "new" state or "enter query" state?).  Centrallix helps to address this issue using the form status widget.  A form status widget displays the current mode of operation that a form is in, as well as whether the form is busy processing a query, save, or delete operation.  This clear presentation of the form's mode is intended to clear up any confusion created by a multi-mode form.  This widget is a special-case form element.</p>
 
 		</overview>
 
@@ -1718,7 +1674,7 @@ form1 "widget/form"
 		<properties>
 
 			<property name="form" type="string">The name of the form that this instance of form status corresponds to.</property>
-		
+
 			<property name="style" type="string">Sets the style of the form widget.  Can be "small", "large", or "largeflat".</property>
 
 			<property name="x" type="integer">Allows you to set x position in pixels relative to the window.</property>
@@ -1745,13 +1701,9 @@ form1 "widget/form"
 
 		</events>
 
-		<actions>
-		
-		</actions>
-
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -1765,11 +1717,12 @@ formstatus "widget/formstatus"
 
     }
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
+
 
 	<widget name="frameset" type="widget/frameset" visual="yes" formelement="no" container="yes" description="A visual container used to create a DHTML frameset within which page widgets can be placed">
 
@@ -1781,35 +1734,35 @@ formstatus "widget/formstatus"
 
 		<usage>
 
-			<p>The frameset can either be a top-level widget, or can be contained within a frameset (for subframes).The frameset widget should not be used anywhere else in an application. The frameset should contain only other framesets and/or pages.</p>
+			<p>The frameset can either be a top-level widget, or can be contained within a frameset (for subframes).The frameset widget should not be used anywhere else in an application.  The frameset should contain only other framesets and/or pages.</p>
 
 		</usage>
 
 		<properties>
 
-		    <property name="borderwidth" type="integer">Number of pixels wide the border(s) between the frame(s) are. Can be set to zero.</property>
+			<property name="borderwidth" type="integer">Number of pixels wide the border(s) between the frame(s) are.  Can be set to zero.</property>
 
-		    <property name="direction" type="string" enum="rows,columns">Whether the frames are arranged in rows or columns.  Set this attribute to "rows" or "columns"respectively.</property>
+			<property name="direction" type="string" enum="rows,columns">Whether the frames are arranged in rows or columns.  Set this attribute to "rows" or "columns"respectively.</property>
 
-		    <property name="title" type="string">Title of the frameset for an html page.</property>
+			<property name="title" type="string">Title of the frameset for an html page.</property>
 
 		</properties>
 
 		<children>
 
-		    <child type="any">
+			<child type="any">
 
-			    <childproperty name="framesize" type="integer/string">Large this frame will be.Can either be expressed as an integer, which represents "50%".</childproperty>
+				<childproperty name="framesize" type="integer/string">Large this frame will be.Can either be expressed as an integer, which represents "50%".</childproperty>
 
-			    <childproperty name="marginwidth" type="integer">Width, in pixels, of the margins of the frame.</childproperty>
-				
-		    </child>
+				<childproperty name="marginwidth" type="integer">Width, in pixels, of the margins of the frame.</childproperty>
+
+			</child>
 
 		</children>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -1865,11 +1818,12 @@ BigFrameset "widget/frameset"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
+
 
 	<widget name="hbox" type="widget/hbox" description="Container which automatically positions its children" visual="yes" formelement="no" container="yes" osrcclient="no">
 
@@ -1878,13 +1832,14 @@ BigFrameset "widget/frameset"
 			<p>An autolayout widget with style set to "hbox".  See "widget/autolayout".</p>
 
 		</overview>
-		
+
 		<usage>See "widget/autolayout"</usage>
 
-		<properties/>
+		<properties />
 
 	</widget>
-	
+
+
 	<widget name="hints" type="widget/hints" description="Contains default values and modifier settings for various components" visual="no" formelement="yes" container="no">
 
 		<overview>
@@ -1895,66 +1850,49 @@ BigFrameset "widget/frameset"
 
 		<usage>
 
-			<p>The hints widget can be placed inside of any visual component. Hints do not contain visual widgets.</p>
+			<p>The hints widget can be placed inside of any visual component.  Hints do not contain visual widgets.</p>
 
 		</usage>
 
 		<properties>
 
 			<property name="allowchars" type="string">Defines a set of acceptable characters (e.g. allowchars="0123456789").</property>
-			
+
 			<property name="badchars" type="string">Defines a set of unacceptable characters.</property>
 
 			<property name="constraint" type="object">Defines a condition that the parent value must meet to be valid.</property>
-			
+
 			<property name="default" type="object">A string or integer that specifies the initial, default, starting value for the component which containing this widget/hints widget.</property>
 
 			<property name="enumlist" type="object">A list of string values that give all the possible values of th the parent.</property>
-			
+
 			<property name="enumquery" type="string">A sql query that is used to get the required value list.</property>
-			
+
 			<property name="format" type="string">The way in which data is presented to the user.</property>
 
 			<property name="groupid" type="integer">A numeric identification for a group of attributes.</property>
 
 			<property name="groupname" type="string">A string identification for a group of attributes.</property>
-					
+
 			<property name="height" type="integer">Determines rows of the widget.</property>
-			
+
 			<property name="length" type="integer">Length in characters that can be entered into this field.</property>
-			
+
 			<property name="max" type="object">A string or integer that stores the maximum value of the attributes of its parent widget.</property>
-			
+
 			<property name="min" type="object">A string or integer that stores the minimum value of the attributes of its parent widget.</property>
-			
+
 			<property name="readonlybits" type="object">If the field is a bitmask, determines which ones are read only.</property>
-			
+
 			<property name="style" type="string">Optional: contains a combination of 1 or more items following set {readonly, alwaysdef} separated by a comma if multiple items are chosen.</property>
 
 			<property name="width" type="integer">Number of characters in the field shown to the user at once.</property>
 
-			
 		</properties>
-
-		<children>
-
-		</children>
-
-		<events>
-
-		</events>
-
-		<actions>
-		
-		</actions>
-
-		<clientprops>
-
-		</clientprops>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -1982,17 +1920,18 @@ f_trx_mod "widget/checkbox"
 
 	}
 
-}		]]>
+}			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="html" type="widget/html" visual="yes" container="no" formelement="no" description="A miniature HTML browser control, capable of viewing and navigating simple web documents.">
 
 		<overview>
 
-			<p>The HTML area widget provides a way to insert a plain HTML document into a Centrallix generated page, either in-flow (static) or in its own separate layer that can be reloaded at will (dynamic). The HTML document can either be given in a property of the widget or can be referenced so that the HTML is read from an external document.</p>
+			<p>The HTML area widget provides a way to insert a plain HTML document into a Centrallix generated page, either in-flow (static) or in its own separate layer that can be reloaded at will (dynamic).  The HTML document can either be given in a property of the widget or can be referenced so that the HTML is read from an external document.</p>
 
 			<p>The HTML area widget also can act as a mini-browser -- clicking on hyper-text links in the visible document will by default cause the link to be followed, and the new document to be displayed in the HTML area (if the HTML area is dynamic).</p>
 
@@ -2008,36 +1947,28 @@ f_trx_mod "widget/checkbox"
 
 		<properties>
 
-		    <property name="content" type="string">Static contents for the HTML area. Usually used in lieu of "source" (see below).</property>
+			<property name="content" type="string">Static contents for the HTML area.  Usually used in lieu of "source" (see below).</property>
 
-		    <property name="epilogue" type="string">HTML source to be inserted at the end of the HTML document.</property>
+			<property name="epilogue" type="string">HTML source to be inserted at the end of the HTML document.</property>
 
-		    <property name="height" type="integer">height, in pixels, of the HTML area as a whole.</property>
+			<property name="height" type="integer">height, in pixels, of the HTML area as a whole.</property>
 
-		    <property name="mode" type="string">Either "static" or "dynamic", and determines whether the HTML area is in-flow ("static") can be positioned and reloaded at-will.</property>
+			<property name="mode" type="string">Either "static" or "dynamic", and determines whether the HTML area is in-flow ("static") can be positioned and reloaded at-will.</property>
 
-		    <property name="prologue" type="string">HTML source to be inserted at the beginning of the HTML document.</property>
+			<property name="prologue" type="string">HTML source to be inserted at the beginning of the HTML document.</property>
 
-		    <property name="source" type="string">The objectsystem path or URL containing the document to be loaded into the HTML as  local server.</property>
+			<property name="source" type="string">The objectsystem path or URL containing the document to be loaded into the HTML as local server.</property>
 
-		    <property name="width" type="integer">Width, in pixels, of the HTML area as a whole.</property>
+			<property name="width" type="integer">Width, in pixels, of the HTML area as a whole.</property>
 
-		    <property name="x" type="integer">Dynamic HTML areas, the x coordinate on the container of its upper left corner.</property>
+			<property name="x" type="integer">Dynamic HTML areas, the x coordinate on the container of its upper left corner.</property>
 
-		    <property name="y" type="integer">Dynamic HTML areas, the y coordinate on the container of its upper left corner.</property>
+			<property name="y" type="integer">Dynamic HTML areas, the y coordinate on the container of its upper left corner.</property>
 
 		</properties>
-		
 
-
-		<actions>
-
-		    <action name="LoadPage">Loadpage action takes two parameters. "Source" contains the URL for the new page to be loaded into the HTML area.The optional parameter "Transition" indicates the type of fade to be used between one page and the next.Currently supported values are "pixelate", "rlwipe", and "lrwipe".</action>
-
-		</actions>
-		
 		<events>
-		
+
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the checkbox.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the checkbox for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
 			<event name="MouseMove">This event occurs when the user moves the mouse pointer while it is over the checkbox.  The event will repeatedly fire each time the pointer moves.</event>
@@ -2050,9 +1981,15 @@ f_trx_mod "widget/checkbox"
 
 		</events>
 
+		<actions>
+
+			<action name="LoadPage">Loadpage action takes two parameters.  "Source" contains the URL for the new page to be loaded into the HTML area.The optional parameter "Transition" indicates the type of fade to be used between one page and the next.Currently supported values are "pixelate", "rlwipe", and "lrwipe".</action>
+
+		</actions>
+
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -2070,12 +2007,13 @@ HTMLArea "widget/html"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
-	
+
+
 	<widget name="image" type="widget/image" visual="yes" formelement="yes" container="no" osrcclient="no" description="A picture (image).">
 
 		<overview>
@@ -2093,7 +2031,7 @@ HTMLArea "widget/html"
 		</usage>
 
 		<properties>
-		
+
 			<property name="aspect" type="sting">Determines wither the image can be stretched or must stay its original aspect ration.</property>
 
 			<property name="fieldname" type="string">If using a form for the image path, the name of the column in the datasource you want to reference.</property>
@@ -2103,7 +2041,7 @@ HTMLArea "widget/html"
 			<property name="height" type="integer">Height, in pixels, of the image.</property>
 
 			<property name="text" type="string">The words that come up if the image object cannot find its source and display an image.</property>
-			
+
 			<property name="width" type="integer">Width, in pixels, of the image.</property>
 
 			<property name="x" type="integer">X-coordinate of the upper left corner of the image, relative to its container.</property>
@@ -2111,10 +2049,22 @@ HTMLArea "widget/html"
 			<property name="y" type="integer">Y-coordinate of the upper left corner of the image, relative to its container.</property>
 
 		</properties>
-		
+
+		<clientprops>
+
+			<clientprop name="scale" type="integer">Determines how much the image grows or shrinks compared to the original.</clientprop>
+
+			<clientprop name="source" type="string">An OSML pathname for the location of the image (such as a png or jpg file).</clientprop>
+
+			<clientprop name="xoffset" type="integer">Distance it is along the x axis from its parent widget.</clientprop>
+
+			<clientprop name="yoffset" type="integer">Distance it is along the y axis from its parent widget.</clientprop>
+
+		</clientprops>
+
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the checkbox. No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the checkbox.  No parameters are available from this event.</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the checkbox.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the checkbox for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
@@ -2127,30 +2077,19 @@ HTMLArea "widget/html"
 			<event name="MouseUp">This event occurs when the user releases the mouse button on the checkbox.</event>
 
 		</events>
-		
-		<clientprops>
 
-			<clientprop name="scale" type="integer">Determines how much the image grows or shrinks compared to the original.</clientprop>
-		
-			<clientprop name="source" type="string">An OSML pathname for the location of the image (such as a png or jpg file).</clientprop>
-
-			<clientprop name="xoffset" type="integer">Distance it is along the x axis from its parent widget.</clientprop>
-			
-			<clientprop name="yoffset" type="integer">Distance it is along the y axis from its parent widget.</clientprop>
-			
-		</clientprops>
-		
 		<actions>
-		
+
 			<action name="LoadImage">Displays the image to user.</action>
-			
+
 			<action name="Offset">Reloads the image with new offset values.</action>
-			
+
 			<action name="Scale">Reloads the image with a new scale value.</action>
-		
+
 		</actions>
 
 	</widget>
+
 
 	<widget name="imagebutton" type="widget/imagebutton" visual="yes" formelement="no" container="no" osrcclient="no" description="A button widget which uses a set of images to control its appearance.">
 
@@ -2162,7 +2101,7 @@ HTMLArea "widget/html"
 
 			<p>ImageButtons can also be disabled, and a "disabled" image is displayed at that time.</p>
 
-			<p>Unlike the textbutton, there is no 'tristate' property for an imagebutton; to make an imagebutton tri-state (different image when idle vs. when pointed to), use a 'pointimage', otherwise do not specify 'pointimage'.</p>
+			<p>Unlike the textbutton, there is no 'tristate' property for an imagebutton; to make an imagebutton tri-state (different image when idle vs.  when pointed to), use a 'pointimage', otherwise do not specify 'pointimage'.</p>
 
 		</overview>
 
@@ -2182,12 +2121,12 @@ HTMLArea "widget/html"
 
 			<property name="image" type="string">The pathname of the image to be shown when the button is "idle".</property>
 
-			<property name="pointimage" type="string">The pathname of the image to be shown when the button is pointed-to.  Defaults to  the 'image' if not specified.</property>
+			<property name="pointimage" type="string">The pathname of the image to be shown when the button is pointed-to.  Defaults to the 'image' if not specified.</property>
 
 			<property name="repeat" type="yes/no">Whether to repeat the click event multiple times while the user holds down the button.</property>
 
 			<property name="tooltip" type="string">The text that appears when the courser hovers over the image button.</property>
-			
+
 			<property name="width" type="integer">Width, in pixels, of the image button.</property>
 
 			<property name="x" type="integer">X-coordinate of the upper left corner of the button, relative to its container.</property>
@@ -2196,13 +2135,15 @@ HTMLArea "widget/html"
 
 		</properties>
 
-		<children>
+		<clientprops>
 
-		</children>
+			<clientprop name="enabled" type="yes/no or expr">Whether or not the imagebutton should be enabled.  Defaults to 'yes'.  Can be an expression that if uses runclient() will cause the enabled status of the imagebutton to 'follow' the value of that expression while the application is running.</clientprop>
+
+		</clientprops>
 
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the button. No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the button.  No parameters are available from this event.</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the checkbox.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the checkbox for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
@@ -2223,16 +2164,10 @@ HTMLArea "widget/html"
 			<action name="Enable">This action causes the image button to enter its 'enabled' state, possibly changing its appearance if a 'disabledimage' was explicitly specified.</action>
 
 		</actions>
-		
-		<clientprops>
-		
-			<clientprop name="enabled" type="yes/no or expr">Whether or not the imagebutton should be enabled.  Defaults to 'yes'.  Can be an expression that if uses runclient() will cause the enabled status of the imagebutton to 'follow' the value of that expression while the application is running.</clientprop>
-
-		</clientprops>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -2254,11 +2189,12 @@ MyButton "widget/imagebutton"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
+
 
 	<widget name="label" type="widget/label" description="Form element capable of displaying text in a child window" visual="yes" formelement="yes" container="no">
 
@@ -2283,7 +2219,7 @@ MyButton "widget/imagebutton"
 			<property name="align" type="string">Describes how the text should align in the label (e.g. right).</property>
 
 			<property name="allow_break" type="string">It determines if the text can wrap around something.</property>
-			
+
 			<property name="click_fgcolor" type="string">The color (named or #numeric) of the text in the label when the user clicks on the label.</property>
 
 			<property name="fgcolor" type="string">The color (named or #numeric) of the text in the label.</property>
@@ -2295,9 +2231,9 @@ MyButton "widget/imagebutton"
 			<property name="form" type="string">The name of the form that this label is associated with.</property>
 
 			<property name="height" type="string">The height of the label.</property>
-			
+
 			<property name="overflow_ellipsis" type="string">If text is no longer able to display shows an ellipsis.</property>
-			
+
 			<property name="point_fgcolor" type="string">The color (named or #numeric) of the text in the label when the user hovers the mouse over the label.</property>
 
 			<property name="style" type="string">(e.g. bold).</property>
@@ -2305,7 +2241,7 @@ MyButton "widget/imagebutton"
 			<property name="text" type="string">The text that the label is to display.</property>
 
 			<property name="tooltip" type="string">The text displayed when the courser hovers over the widget.</property>
-			
+
 			<property name="valign" type="string">Describes how the text should align vertically within the label (e.g. top, middle, or bottom).</property>
 
 			<property name="width" type="integer">The width of the label.</property>
@@ -2316,13 +2252,15 @@ MyButton "widget/imagebutton"
 
 		</properties>
 
-		<!--<children>
+		<clientprops>
 
-		</children>-->
+			<clientprop name="value" type="string">This property allows a runclient() expression to dynamically supply the text to display in the label.</clientprop>
+
+		</clientprops>
 
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the checkbox. No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the checkbox.  No parameters are available from this event.</event>
 
 			<event name="DataChange">This event occurs when the user has modified the data value of the checkbox (clicked or unclicked it).</event>
 
@@ -2341,18 +2279,12 @@ MyButton "widget/imagebutton"
 		<actions>
 
 			<action name="SetValue">Sets the value property to the given parameter.</action>
-		
+
 		</actions>
-
-		<clientprops>
-
-			<clientprop name="value" type="string">This property allows a runclient() expression to dynamically supply the text to display in the label.</clientprop>
-		
-		</clientprops>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -2362,11 +2294,12 @@ f_trx_mod_l "widget/label" { width=86; text="User Edit?"; align=right; font_size
 
 
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
+
 
 	<widget name="menu" type="widget/menu" visual="yes" formelement="no" container="no" description="A visual pop-up or drop-down menu widget.">
 
@@ -2382,7 +2315,7 @@ f_trx_mod_l "widget/label" { width=86; text="User Edit?"; align=right; font_size
 
 		<usage>
 
-			<p>Menus can be placed inside of any visual container. However, be aware that the menu will be clipped by its container, so placing them at the top-level can be of an advantage. Menu widgets contain menuitem widgets, which are also described in this section.</p>
+			<p>Menus can be placed inside of any visual container.  However, be aware that the menu will be clipped by its container, so placing them at the top-level can be of an advantage.  Menu widgets contain menuitem widgets, which are also described in this section.</p>
 
 		</usage>
 
@@ -2397,7 +2330,7 @@ f_trx_mod_l "widget/label" { width=86; text="User Edit?"; align=right; font_size
 			<property name="bgcolor" type="string">A color, RGB or named, to be used as the menu's background.  If neither bgcolor nor background are specified, the menu is transparent.</property>
 
 			<property name="column_width" type="integer">The width of the data elements in the menu.</property>
-			
+
 			<property name="direction" type="string">Either "horizontal" or "vertical" (default), and determines whether the menu is a drop-down/popup (vertical) or a menubar (horizontal).</property>
 
 			<property name="fgcolor" type="string">A color for the menu's text.</property>
@@ -2407,15 +2340,15 @@ f_trx_mod_l "widget/label" { width=86; text="User Edit?"; align=right; font_size
 			<property name="highlight_background" type="string">A background image for a menu item that is highlighted (pointed at).</property>
 
 			<property name="highlight_bgcolor" type="string">A color, RGB or named, to be used as a highlighted (pointed-at) item's background.  If neither highlight_bgcolor nor highlight_background are specified, the standard color or background is used instead.</property>
-			
+
 			<property name="popup" type="yes/no">Default "no".  Popup menus disappear after an item on them is selected, whereas fixed menus remain visible (such as for menubars).</property>
 
 			<property name="row_height" type="integer">Height, in pixels, of the menu items in a menu.</property>
-			
+
 			<property name="shadow_offset" type="integer">Determines how far the shadow translates from the menu.</property>
-			
+
 			<property name="shadow_radius" type="integer">Describes in a ratio how much larger or smaller the size of the shadow is compared to the window.</property>
-			
+
 			<property name="width" type="integer">Width, in pixels, of the menu.  For menus with a direction of 'vertical', an unspecified width is determined dynamically based on the menu contents.</property>
 
 			<property name="x" type="integer">X-coordinate of the upper left corner of the menu, relative to its container.</property>
@@ -2431,23 +2364,21 @@ f_trx_mod_l "widget/label" { width=86; text="User Edit?"; align=right; font_size
 				<childproperty name="checked" type="yes/no">Optionally, a checkbox can be displayed to the left of the menu item when 'checked' is specified.  In this case, the 'value' can also be a runclient() expression that controls whether the menu item is checked.</childproperty>
 
 				<childproperty name="icon" type="string">Optionally, the pathname of an image file to display to the left of the menu item.</childproperty>
-				
+
 				<childproperty name="label" type="string">The text to appear on the menu item.</childproperty>
 
 				<childproperty name="onright" type="yes/no">If set to "yes", then the menu item will be displayed on the righthand side of a horizontal menu bar (e.g., for having "File" "Edit" "Tools" on the left, and "Help" on the far right).</childproperty>
-				
+
 				<childproperty name="value" type="string">The 'value' of the menu item, passed to the Selected event, below.  If not specified, it defaults to the name of the widget (not its label).</childproperty>
 
 			</child>
 
-			<child type="widget/menusep">
-				
-			</child>
+			<child type="widget/menusep" />
 
 			<child type="widget/menutitle">
 
 				<childproperty name="label" type="string">The text to appear on the menu title.</childproperty>
-				
+
 			</child>
 
 		</children>
@@ -2455,11 +2386,11 @@ f_trx_mod_l "widget/label" { width=86; text="User Edit?"; align=right; font_size
 		<events>
 
 			<event name="DataChange">This event occurs when the an item in the menu which is not a submenu is changed.</event>
-			
+
 			<event name="GetFocus">This event occurs when the menu which previously was not clicked is clicked.</event>
-			
+
 			<event name="LoseFocus">This event occurs when the menu which previously was clicked is unselected.</event>
-		
+
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the checkbox.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the checkbox for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
 			<event name="MouseMove">This event occurs when the user moves the mouse pointer while it is over the checkbox.  The event will repeatedly fire each time the pointer moves.</event>
@@ -2482,7 +2413,7 @@ f_trx_mod_l "widget/label" { width=86; text="User Edit?"; align=right; font_size
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -2508,19 +2439,20 @@ myMenu "widget/menu"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="osrc" type="widget/osrc" visual="no" formelement="no" container="yes" description="A nonvisual widget which handles data communication between forms/tables and the Centrallix server.">
 
 		<overview>
 
-			<p>The objectsource (osrc) widget lies at the core of Centrallix's ability to dynamically exchange data between the server and client. This widget implements a form of "replication" by maintaining a replica of a small segment of data in the user agent.</p>
+			<p>The objectsource (osrc) widget lies at the core of Centrallix's ability to dynamically exchange data between the server and client.  This widget implements a form of "replication" by maintaining a replica of a small segment of data in the user agent.</p>
 
-			<p>Both form and dynamic table widgets interact with the objectsource nonvisual widget to acquire data, update data, create data, and delete data. In fact, it is possible for more than one form and/or table to be connected with a given objectsource, to perform a variety of functions.</p>
+			<p>Both form and dynamic table widgets interact with the objectsource nonvisual widget to acquire data, update data, create data, and delete data.  In fact, it is possible for more than one form and/or table to be connected with a given objectsource, to perform a variety of functions.</p>
 
 			<p>Objectsources offer synchronization with other objectsources via the Sync and DoubleSync actions (see below) or rule-based connnectivity (see widget/rule).  These actions allow the application to contain multiple objectsources with primary key / foreign key relationships, and to have those objectsources automatically stay in synchronization with each other based on those relationships.</p>
 
@@ -2538,22 +2470,21 @@ myMenu "widget/menu"
 
 		<properties>
 
-			<property name="autoquery" type="string">One of oneachreveal, never, onload, onfirstreveal.  (note: this autoquery setting is different from, but related to, the "widget/rule" "autoquery").  "onload" means that the osrc should run its query automatically when the .app containing this osrc is loaded by the user.  "onfirstreveal" means that the osrc should run its query automatically when the data (e.g., a table or form) is first displayed to the user (e.g., the containing childwindow becomes visible or tabpage is selected).  "oneachreveal" means to do so *each* time the data is displayed to the user.  "never" means that the osrc should never query automatically by itself, but it may be triggered by a connector (QueryParam, QueryText, etc.) or by a widget/rule of type osrc_relationship.  Important Note:  If you expect to normally trigger the osrc via a relationship or via QueryParam, it is often *best* to set autoquery to 'never'.  Otherwise, unexpected results can sometimes occur.</property>
+			<property name="autoquery" type="string">One of oneachreveal, never, onload, onfirstreveal.  (note: this autoquery setting is different from, but related to, the "widget/rule" "autoquery").  "onload" means that the osrc should run its query automatically when the .app containing this osrc is loaded by the user.  "onfirstreveal" means that the osrc should run its query automatically when the data (e.g., a table or form) is first displayed to the user (e.g., the containing childwindow becomes visible or tabpage is selected).  "oneachreveal" means to do so *each* time the data is displayed to the user.  "never" means that the osrc should never query automatically by itself, but it may be triggered by a connector (QueryParam, QueryText, etc.) or by a widget/rule of type osrc_relationship.  Important Note: If you expect to normally trigger the osrc via a relationship or via QueryParam, it is often *best* to set autoquery to 'never'.  Otherwise, unexpected results can sometimes occur.</property>
 
 			<property name="baseobj" type="string">If inserts and deletes are to function, the ObjectSystem pathname in which those inserts and deletes should occur.  This should be one of the objects specified in the FROM clause of the SQL statement.</property>
 
 			<property name="filter" type="string">Set of search parameters.</property>
-			
+
 			<property name="indicates_activity" type="yes/no">Whether normal query activity on this objectsource indicates to the server that the user is active.  Some objectsources (in conjunction with a widget/timer) regularly refresh their data; for those, indicates_activity can be set to "no" so that those refreshes don't cause a user's session to never time-out.</property>
 
 			<property name="key_objname" type="string">The name of the object in the SQL query that contains the primary key for the query.</property>
 
 			<property name="readahead" type="integer">Represents the number to fetch from the server when more records are needed from the server (such as when a form requests that the Current Record be a record beyond the end of the current replica contents).</property>
 
-			<property name="receive_updates" type="yes/no">** This feature currently disabled in Centrallix 0.9.1 **  Default "no".  If set to "yes", the objectsource will ask the server to send it updates on any changes that occur on the server side (i.e., if the changes were made by another objectsource or by another user, they would be automatically refreshed into this objectsource in near real-time).</property>
+			<property name="receive_updates" type="yes/no">** This feature currently disabled in Centrallix 0.9.1 ** Default "no".  If set to "yes", the objectsource will ask the server to send it updates on any changes that occur on the server side (i.e., if the changes were made by another objectsource or by another user, they would be automatically refreshed into this objectsource in near real-time).</property>
 
 			<property name="refresh_interval" type="integer">The time between the data refreshing, if set to 0 it does not automatically refresh.</property>
-		
 			<property name="replicasize" type="integer">Represents the number of records to store in its replica.  This value should be larger than the maximum number of records that will be displayed at any one time.  At times, Centrallix may increase the number of records cached on the client beyond this number.</property>
 
 			<property name="revealed_only" type="string">Acts as a boolean and delays query until the osrc is visable (if "true").</property>
@@ -2584,7 +2515,7 @@ myMenu "widget/menu"
 
 				<childproperty name="target" type="string">The target objectsource that this objectsource will be related to.</childproperty>
 
-				<childproperty name="target_key_#" type="string">The field names in the target objectsource to be used for the key value for the relationship (where # is an integer 1 through 5).  These keys can be target_key_1 through target_key_5.</childproperty>				
+				<childproperty name="target_key_#" type="string">The field names in the target objectsource to be used for the key value for the relationship (where # is an integer 1 through 5).  These keys can be target_key_1 through target_key_5.</childproperty>
 
 			</child>
 
@@ -2605,28 +2536,27 @@ myMenu "widget/menu"
 		<events>
 
 			<event name="BeginQuery">This event occurs when a query is opened and the query ID is not null.</event>
-			
+
 			<event name="Created">This event occurs when data is created in the object source.</event>
-			
+
 			<event name="DataFocusChanged">This event is invoked whenever the current record changes to a different record.</event>
 
 			<event name="EndQuery">This event is invoked when a query is completed and the last row(s) retrieved.</event>
 
 			<event name="Modified">This event occurs when data is modified in the object source.</event>
-			
+
 			<event name="Sequenced">This event occurs when replicant entries are swapped.</event>
-			
-			
+
 		</events>
 
 		<actions>
 
 			<action name="BeginCreateObject">Creates a base of an object and notifies all childeren that a child is creating an object.</action>
-						
+
 			<action name="CancelCreateObject">If it is called while an object is being created it stops the creation and cleans up the mess.</action>
-			
+
 			<action name="ChangeSource">Changes the data item that the object source points to in the server.</action>
-		
+
 			<action name="Clear"><ni/>Clears the replica of data.</action>
 
 			<action name="Create"><ni/>Encapsulates data in an array and calls CreateObject.</action>
@@ -2639,7 +2569,7 @@ myMenu "widget/menu"
 
 			<action name="DoubleSync">DEPRECATED: Performs a double synchronization with two other objectsources, known as the Parent and the Child, in two steps.  The first step is like Sync (see below), with a ParentOSRC and ParentKey1-ParentKey9] / ParentSelfKey1-ParentSelfKey9.  Next, a Sync is performed between the current objectsource and the ChildOSRC in the same way the first step performed a sync between the ParentOSRC and the current objectsource, respectively, using SelfChildKey1-SelfChildKey9 / ChildKey1-ChildKey9.</action>
 
-			<action name="FindObject">Searches for a certain object in the replica (retrieved records), and makes it the current object.  Parameters:  To search by record number, set ID equal to the integer (1 = first record).  To search by object name (primary key), set Name equal to a string containing the primary key (note that concatenated keys use | as a separator).  To search by other abitrary field values, set those values in the parameters to this action.</action>
+			<action name="FindObject">Searches for a certain object in the replica (retrieved records), and makes it the current object.  Parameters: To search by record number, set ID equal to the integer (1 = first record).  To search by object name (primary key), set Name equal to a string containing the primary key (note that concatenated keys use | as a separator).  To search by other abitrary field values, set those values in the parameters to this action.</action>
 
 			<action name="First"><ni/>Returns first record in the replica.</action>
 
@@ -2659,7 +2589,7 @@ myMenu "widget/menu"
 
 			<action name="QueryParam">Refreshes the query, and allows new parameter values to be passed in.  Previous comment: Re-runs the SQL query, but adds more constraints.  The additional constraints are provided as parameters to the connector which invokes this action.</action>
 
-			<action name="QueryText">Runs the query, searching for objects whose attributes *contain* a combination of string values.  'query' contains a space-separated list of strings that must be present in each returned record (typically the 'query' is typed by the user).  'field_list' is a comma-separated list of field names to search in.  Each field name (attribute) can be preceded by a * or followed by a *; the presence of these asterisks controls whether the matching is done on the entire attribute value or just as a substring match.  Examples:  'my_key,*my_description*' for field_list means to match exact values for my_key, and match anywhere in my_description.  cx__case_insensitive can be set to 1 to make the search case insensitive.</action>
+			<action name="QueryText">Runs the query, searching for objects whose attributes *contain* a combination of string values.  'query' contains a space-separated list of strings that must be present in each returned record (typically the 'query' is typed by the user).  'field_list' is a comma-separated list of field names to search in.  Each field name (attribute) can be preceded by a * or followed by a *; the presence of these asterisks controls whether the matching is done on the entire attribute value or just as a substring match.  Examples: 'my_key,*my_description*' for field_list means to match exact values for my_key, and match anywhere in my_description.  cx__case_insensitive can be set to 1 to make the search case insensitive.</action>
 
 			<action name="Refresh">Re-runs the SQL query using the previously stored parameter values (if any).  This is used when the data on the server is believed to have changed, and the new data is desired to be displayed in the application.  This action does not change the current row.</action>
 
@@ -2668,16 +2598,16 @@ myMenu "widget/menu"
 			<action name="Sync">DEPRECATED: Performs a synchronization operation with another objectsource by re-running the query for this objectsource based on another objectsource's data.  Used for implementing relationships between objectsources.  The ParentOSRC (string) parameter specifies the name of the objectsource to sync with.  Up to nine synchronization keys can be specified, as ParentKey1 and ChildKey1 through ParentKey9 and ChildKey9.  The ParentKey indicates the name of the field in the ParentOSRC to sync with (probably a primary key), and ChildKey indicates the name of the field (the foreign key) in the current objectsource to match with the parent objectsource.</action>
 
 			<action name="SaveClients">Save the clients that connect and lets clients of clients know that orsc is conected to them.</action>
-			
+
 			<action name="SeqBackward">Moves the current row backwards.</action>
-			
+
 			<action name="SeqForward">Moves the current row forwards.</action>
-			
+
 		</actions>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -2709,17 +2639,18 @@ osrc1 "widget/osrc"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="page" type="widget/page" visual="yes" formelement="no" container="yes" description="The top-level container that represents a Centrallix application.">
 
 		<overview>
 
-			<p>The page widget represents the HTML application (or subapplication) as a whole and serves as a top-level container for other widgets in the application.  The page widget also implements some important functionality regarding the management of keypresses, focus, widget resizing, and event management. When creating an application, the top-level object in the application must either be "widget/page" or "widget/frameset", where the latter is used to create a multi-framed application containing multiple page widgets.</p>
+			<p>The page widget represents the HTML application (or subapplication) as a whole and serves as a top-level container for other widgets in the application.  The page widget also implements some important functionality regarding the management of keypresses, focus, widget resizing, and event management.  When creating an application, the top-level object in the application must either be "widget/page" or "widget/frameset", where the latter is used to create a multi-framed application containing multiple page widgets.</p>
 
 			<p>Page widgets specify the colors for mouse, keyboard, and data focus for the application.  Focus is usually indicated via the drawing of a rectangle around a widget or data item, and for a 3D-effect two colors are specified for each type of focus: a color for the top and left of the rectangle, and another color for the right and bottom of the rectangle.  Mouse focus gives feedback to the user as to which widget they are pointing at (and thus which one will receive keyboard and/or data focus if the user clicks the mouse).  Keyboard focus tells the user which widget will receive data entered via the keyboard.  Data focus tells the user which record or data item is selected in a widget.</p>
 
@@ -2727,17 +2658,17 @@ osrc1 "widget/osrc"
 
 		<usage>
 
-			<p>The page widget cannot be embedded within other widgets on a page. There must only be one per page, unless a frameset is used, in which case page widgets may be added within a frameset widget.</p>
+			<p>The page widget cannot be embedded within other widgets on a page.  There must only be one per page, unless a frameset is used, in which case page widgets may be added within a frameset widget.</p>
 
 		</usage>
 
 		<properties>
 
 			<property name="attract" type="integer">Determines how close the window is to the browser edge.</property>
-			
+
 			<property name="background" type="string">A background image for the page.</property>
 
-			<property name="bgcolor" type="string">The background color for the page. Can either be a recognized color (such as "red"), or an RGB color (such as "#C0C0C0").</property>
+			<property name="bgcolor" type="string">The background color for the page.  Can either be a recognized color (such as "red"), or an RGB color (such as "#C0C0C0").</property>
 
 			<property name="datafocus1" type="string">A color, RGB or named, for the top and left edges of rectangles drawn to indicate data focus (default is dark blue).</property>
 
@@ -2752,17 +2683,17 @@ osrc1 "widget/osrc"
 			<property name="http_frame_options" type="string">When the application is rendered over HTTP/HTML, this controls the X-Frame-Options anti-clickjacking HTTP response header.  Possible values are "none", "sameorigin", and "deny".  The default value is set by the x_frame_options setting in the "net_http" section of centrallix.conf (see configuration docs for more information).  The http_frame_options setting only applies to the page widget it is set in, not to any components that the page loads (it can be set in those components separately if needed).</property>
 
 			<property name="icon" type="string">The file path to the page icon.</property>
-			
+
 			<property name="kbdfocus1" type="string">A color, RGB or named, to be used for the top and left edges of rectangles drawn to indicate keyboard focus (default is "white").</property>
 
 			<property name="kbdfocus2" type="string">A color, RGB or named, for the bottom and right edges of rectangles drawn to indicate keyboard focus (default is dark grey).</property>
 
 			<property name="linkcolor" type="string">Color for hyper links.</property>
-			
+
 			<property name="loadstatus" type="string">True if page is loaded, false otherwise.</property>
-			
+
 			<property name="max_requests" type="integer">The maximum amount of server requests at one time.</property>
-			
+
 			<property name="mousefocus1" type="string">A color, RGB or named, to be used for the top and left edges of rectangles drawn to indicate mouse focus (default is "black").</property>
 
 			<property name="mousefocus2" type="string">A color, RGB or named, for the bottom and right edges of rectangles drawn to indicate mouse focus (default is "black").</property>
@@ -2780,15 +2711,10 @@ osrc1 "widget/osrc"
 
 		</properties>
 
-		<!--<children>
-
-		</children>-->
-
-
 		<events>
-		
+
 			<event name="Load">This occurs when the page initializes.</event>
-		
+
 			<event name="RightClick">This occurs when the uses right clicks on a mouse or mouse pad.</event>
 
 		</events>
@@ -2796,18 +2722,19 @@ osrc1 "widget/osrc"
 		<actions>
 		
 			<action name="Alert">Sends an alert widget.</action>
-		
 			<action name="Close">Closes the page.</action>
-		
+
 			<action name="Launch">Starts a new app in a new window.</action>
 			
 			<action name="LoadPage">Loads the page.</action>
+
+			<action name="ReloadPage">Reloads the page in the user's browser.  Note: This event forces a reload, even if the original content could be loaded without one.</action>
 
 		</actions>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -2831,17 +2758,18 @@ MyPage "widget/page"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="pane" type="widget/pane" visual="yes" formelement="no" container="yes" description="A visible rectangular container widget with a border">
 
 		<overview>
 
-			<p>The pane is Centrallix's simplest container. It consists only of a background and a border, which can either have a "raised" edge or "lowered" edge style.</p>
+			<p>The pane is Centrallix's simplest container.  It consists only of a background and a border, which can either have a "raised" edge or "lowered" edge style.</p>
 
 		</overview>
 
@@ -2858,7 +2786,7 @@ MyPage "widget/page"
 			<property name="bgcolor" type="string">A color, RGB or named, to be used as the pane's background.  If neither bgcolor nor background is specified, the pane will be transparent.</property>
 
 			<property name="border_radius" type="integer"> The radius (sharpness) of the pane, smaller is more sharp.</property>
-			
+
 			<property name="border_color" type="string">For "bordered" pane styles, this is the color of the border, either named or a #number.</property>
 
 			<property name="height" type="integer">Height, in pixels, of the pane.</property>
@@ -2879,19 +2807,15 @@ MyPage "widget/page"
 
 		</properties>
 
-		<children>
-
-		</children>
-		
 		<clientprops>
-		
+
 			<clientprop name="enable" type="string">Indicates if the user can interact with the pane (if so "true").</clientprop>
-			
+
 		</clientprops>
 
 		<events>
-		
-			<event name="Click">This event occurs when the user clicks the checkbox. No parameters are available from this event.</event>
+
+			<event name="Click">This event occurs when the user clicks the checkbox.  No parameters are available from this event.</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the checkbox.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the checkbox for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
@@ -2908,16 +2832,16 @@ MyPage "widget/page"
 		<actions>
 
 			<action name="Point">Creates a triangular pointer on the edge of a pane to point at a given (X,Y) coordinate.</action>
-			
+
 			<action name="Resize">Changes the width and height of the pane to the given (Width,Height).</action>
-			
+
 			<action name="SetBackground">Sets the backgound image or color of the pane, using the attribute Color or Image.</action>
-		
+
 		</actions>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -2933,11 +2857,12 @@ mypane "widget/pane"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
+
 
 	<widget name="parameter" type="widget/parameter" visual="no" formelement="no" container="no" description="A declaration of a parameter that can be passed to an application or component" osrcclient="no">
 
@@ -2964,23 +2889,23 @@ mypane "widget/pane"
 			<property name="find_container" type="string">If this is a parameter to a component, and the parameter has type "object", this can be set to a type of widget that should be searched for in the containing application or component once the component is instantiated.  Note that the object being searched for must be a container of the component instance, either directly or indirectly.  This option is frequently used to link in with a form or objectsource in the contianing application or component, without that form or objectsource having to be explicitly passed to the component.</property>
 
 			<property name="param_name" type="string">Gives the name of the parameter being passed, thus allowing the parameter widget name (which must be unique within the application or component) to be different from the parameter name as referenced within expressions, SQL, or connectors.</property>
-			
+
 			<property name="type" type="string">The data type of the parameter.  Can be "integer", "string", "double", "datetime", "money", or "object".</property>
 
 		</properties>
 
-		<actions>
-		
-			<action name="SetValue">This sets the value of the parameter.</action>
-		
-		</actions>
-		
 		<events>
-		
+
 			<event name="DataChange">This event occurs when the parameter being passed is changed.</event>
-		
+
 		</events>
-		
+
+		<actions>
+
+			<action name="SetValue">This sets the value of the parameter.</action>
+
+		</actions>
+
 		<sample>
 
 			<![CDATA[
@@ -3039,6 +2964,7 @@ my_cmp "widget/component-decl"
 
 	</widget>
 
+
 	<widget name="radiobuttonpanel" type="widget/radiobuttonpanel" visual="yes" formelement="yes" container="no" description="A visual widget displaying a set of 'radio buttons'">
 
 		<overview>
@@ -3057,45 +2983,45 @@ my_cmp "widget/component-decl"
 
 		<properties>
 
-		    <property name="fieldname" type="string">Name of the column in the datasource you want to reference.</property>
+			<property name="fieldname" type="string">Name of the column in the datasource you want to reference.</property>
 
-		    <property name="background" type="string" subtype="image">A background image for the radio button panel.</property>
+			<property name="background" type="string" subtype="image">A background image for the radio button panel.</property>
 
-		    <property name="bgcolor" type="string" subtype="color">A color, RGB or named, for the panel background. If neither bgcolor nor background transparent.</property>
+			<property name="bgcolor" type="string" subtype="color">A color, RGB or named, for the panel background.  If neither bgcolor nor background transparent.</property>
 
 		    <property name="height" type="integer">Height, in pixels, of the panel.</property>
 			
 		    <property name="outline_background" type="string" subtype="color">An image to be used for the rectangular border drawn around the radio buttons.</property>
 
-		    <property name="textcolor" type="string" subtype="color">The color, RGB or named, of the text within the panel.  Default: "black".</property>
+			<property name="textcolor" type="string" subtype="color">The color, RGB or named, of the text within the panel.  Default: "black".</property>
 
-		    <property name="title" type="string">The title for the radio button panel, which appears superimposed on the rectangular   border around the radio buttons.</property>
+			<property name="title" type="string">The title for the radio button panel, which appears superimposed on the rectangular border around the radio buttons.</property>
 
-		    <property name="width" type="integer">Width, in pixels, of the panel.</property>
+			<property name="width" type="integer">Width, in pixels, of the panel.</property>
 
-		    <property name="x" type="integer">X-coordinate of the upper left corner of the panel, default is 0.</property>
+			<property name="x" type="integer">X-coordinate of the upper left corner of the panel, default is 0.</property>
 
-		    <property name="y" type="integer">Y-coordinate of the upper left corner of the panel, default is 0.</property>
+			<property name="y" type="integer">Y-coordinate of the upper left corner of the panel, default is 0.</property>
 
 		</properties>
 
 		<children>
 
-		    <child type="widget/radiobutton">
+			<child type="widget/radiobutton">
 
-			    <childproperty name="label" type="string">The text label to appear beside the radio button.</childproperty>
-				
-			    <childproperty name="selected" type="boolean">the radio button is initially selected or not. Should only be set on one radio Default;"false".</childproperty>
+				<childproperty name="label" type="string">The text label to appear beside the radio button.</childproperty>
 
-			    <childproperty name="value" type="string">The value of the selected item.</childproperty>
+				<childproperty name="selected" type="boolean">the radio button is initially selected or not.  Should only be set on one radio Default;"false".</childproperty>
 
-		    </child>
+				<childproperty name="value" type="string">The value of the selected item.</childproperty>
+
+			</child>
 
 		</children>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -3119,19 +3045,20 @@ testradio "widget/radiobuttonpanel"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="remotectl" type="widget/remotectl" visual="no" formelement="no" container="no" description="Nonvisual widget permitting events to be passed in from a remote Centrallix application">
 
 		<overview>
 
-			<p>The remote control nonvisual widget allows for one application (or instance of an application) to activate Actions in another running application, even if those applications are on two separate client computer systems. This is done by passing the event/action information through a remote control channel on the server.</p>
+			<p>The remote control nonvisual widget allows for one application (or instance of an application) to activate Actions in another running application, even if those applications are on two separate client computer systems.  This is done by passing the event/action information through a remote control channel on the server.</p>
 
-			<p>Two remote control widgets are required: a master and slave. This widget is the slave widget, which receives remote control events via the Centrallix server. When a master widget (remotemgr) sends an event through the channel, this slave widget is automatically activated and can then trigger the appropriate action on another widget on the page.</p>
+			<p>Two remote control widgets are required: a master and slave.  This widget is the slave widget, which receives remote control events via the Centrallix server.  When a master widget (remotemgr) sends an event through the channel, this slave widget is automatically activated and can then trigger the appropriate action on another widget on the page.</p>
 
 			<p>In order for the remote control event to be passed through Centrallix, the master and slave widgets must both be using the same channel id and be logged in with the same username.They need not be a part of the same session on the server.</p>
 
@@ -3145,25 +3072,18 @@ testradio "widget/radiobuttonpanel"
 
 		</usage>
 
-		<properties/>
-
-		<sample>
-
-		<![CDATA[
-
-		]]>
-
-		</sample>
+		<properties />
 
 	</widget>
+
 
 	<widget name="remotemgr" type="widget/remotemgr" visual="no" formelement="no" container="no" description="Nonvisual widget permitting the application to send events to a remote Centrallix application">
 
 		<overview>
 
-			<p>The remote control manager nonvisual widget allows for one application (or instance of an application) to activate Actions in another running application, even if those applications are on two separate client computer systems. This is done by passing the event/action information through a remote control channel on the server.</p>
+			<p>The remote control manager nonvisual widget allows for one application (or instance of an application) to activate Actions in another running application, even if those applications are on two separate client computer systems.  This is done by passing the event/action information through a remote control channel on the server.</p>
 
-			<p>Two remote control widgets are required: a master and slave. This widget is the master widget, which sends remote control events via the Centrallix server. When a this widget sends an event through the channel, the slave widget (remotectl) is automatically activated and can then trigger the appropriate action on another widget on the remote application's page.</p>
+			<p>Two remote control widgets are required: a master and slave.  This widget is the master widget, which sends remote control events via the Centrallix server.  When a this widget sends an event through the channel, the slave widget (remotectl) is automatically activated and can then trigger the appropriate action on another widget on the remote application's page.</p>
 
 			<p>In order for the remote control event to be passed through Centrallix, the master and slave widgets must both be using the same channel id and be logged in with the same username.They need not be a part of the same session on the server.</p>
 
@@ -3177,43 +3097,36 @@ testradio "widget/radiobuttonpanel"
 
 		</usage>
 
-		<properties/>
-
-		<sample>
-
-		<![CDATA[
-
-		]]>
-
-		</sample>
+		<properties />
 
 	</widget>
 
+
 	<widget name="repeat" type="widget/repeat" visual="no" formelement="no" container="yes" description="Repeat a subtree of widgets">
 
-	    <overview>
+		<overview>
 
-		<p>The 'repeat' nonvisual widget is used to repeat its entire subtree of widgets for each record in an sql query.</p>
+			<p>The 'repeat' nonvisual widget is used to repeat its entire subtree of widgets for each record in an sql query.</p>
 
-	    </overview>
+		</overview>
 
-	    <usage>
+		<usage>
 
-		<p>This widget has no content of its own, so it is only useful if it has widgets inside it.  For positioning of visual widgets inside a widget/repeat, an hbox or vbox (outside the widget/repeat) can be used, or the x and y can be set mathematically based on results from the SQL query.</p>
+			<p>This widget has no content of its own, so it is only useful if it has widgets inside it.  For positioning of visual widgets inside a widget/repeat, an hbox or vbox (outside the widget/repeat) can be used, or the x and y can be set mathematically based on results from the SQL query.</p>
 
-		<p>The widget/repeat can be useful in creating data-driven user interfaces, as well as in facilitating a plug-in architecture in your application.  For instance, the SQL query could retrieve a list of matching components to be included in an interface, and the repeat widget could create components, tabs, windows, table columns, buttons, etc., for each returned SQL query record.</p>
+			<p>The widget/repeat can be useful in creating data-driven user interfaces, as well as in facilitating a plug-in architecture in your application.  For instance, the SQL query could retrieve a list of matching components to be included in an interface, and the repeat widget could create components, tabs, windows, table columns, buttons, etc., for each returned SQL query record.</p>
 
-	    </usage>
+		</usage>
 
-	    <properties>
+		<properties>
 
 			<property name="sql" type="string">The sql query that will be run on the server.</property>
 
-	    </properties>
+		</properties>
 
-	    <sample>
+		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -3247,11 +3160,12 @@ $Version=2$
 
 	    }
 
-		]]>
+			]]>
 
 	    </sample>
 
 	</widget>
+
 
 	<widget name="rule" type="widget/rule" visual="no" formelement="no" container="no" description="Declares a rule - a behavior expected from a widget.">
 
@@ -3275,6 +3189,7 @@ $Version=2$
 
 	</widget>
 
+
 	<widget name="scrollbar" type="widget/scrollbar" visual="yes" formelement="no" container="no" description="A scrollbar with a thumb">
 
 		<overview>
@@ -3293,53 +3208,54 @@ $Version=2$
 
 		<properties>
 
-		    <property name="background" type="string" subtype="image">A background image to be placed behind the scrollbar.</property>
+			<property name="background" type="string" subtype="image">A background image to be placed behind the scrollbar.</property>
 
-		    <property name="bgcolor" type="string" subtype="color">A color, RGB or named, to be used as the scrollbar background. If neither bgcolor nor background is supplied, the scrollbar is transparent.</property>
+			<property name="bgcolor" type="string" subtype="color">A color, RGB or named, to be used as the scrollbar background.  If neither bgcolor nor background is supplied, the scrollbar is transparent.</property>
 
-		    <property name="direction" type="string">Either "horizontal" or "vertical" indicating the visible direction that the scrollbar is oriented.</property>
+			<property name="direction" type="string">Either "horizontal" or "vertical" indicating the visible direction that the scrollbar is oriented.</property>
 
-		    <property name="height" type="integer">Height, in pixels, of the scrollbar.</property>
+			<property name="height" type="integer">Height, in pixels, of the scrollbar.</property>
 
-		    <property name="range" type="integer">The upper limit of the range of the scrollbar's value.  The value will range from 0 to the number specified by 'range'.  This property can be set to a runclient() dynamic expression, in which case the range will change as the expression changes.</property>
+			<property name="range" type="integer">The upper limit of the range of the scrollbar's value.  The value will range from 0 to the number specified by 'range'.  This property can be set to a runclient() dynamic expression, in which case the range will change as the expression changes.</property>
 
 			<property name="visible" type="string"> This acts as a boolean to denote if the scroll bar is visible ("true" is visible).</property>
-			
-		    <property name="width" type="integer">Width, in pixels, of the scrollbar.</property>
 
-		    <property name="x" type="integer">X-coordinate of the upper left corner of the scrollbar, relative to its container.</property>
+			<property name="width" type="integer">Width, in pixels, of the scrollbar.</property>
 
-		    <property name="y" type="integer">Y-coordinate of the upper left corner of the scrollbar, relative to its container.</property>
+			<property name="x" type="integer">X-coordinate of the upper left corner of the scrollbar, relative to its container.</property>
+
+			<property name="y" type="integer">Y-coordinate of the upper left corner of the scrollbar, relative to its container.</property>
 
 		</properties>
-		
-		<actions>
-		
-			<action name="MoveTo">Sets the scroll bar to a specific location determined by the parameter.</action>
-		
-		</actions>
-		
+
 		<events>
-		
+
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
 			<event name="MouseMove">This event occurs when the user moves the mouse pointer while it is over the widget.  The event will repeatedly fire each time the pointer moves.</event>
 
 			<event name="MouseOut">This event occurs when the user moves the mouse pointer off of the widget.</event>
-			
+
 			<event name="MouseOver">This event occurs when the user first moves the mouse pointer over the widget.  It will not occur again until the user moves the mouse off of the widget and then back over it again.</event>
 
 			<event name="MouseUp">This event occurs when the user releases the mouse button on the widget.</event>
 
 		</events>
 
+		<actions>
+
+			<action name="MoveTo">Sets the scroll bar to a specific location determined by the parameter.</action>
+
+		</actions>
+
 	</widget>
+
 
 	<widget name="scrollpane" type="widget/scrollpane" visual="yes" formelement="no" container="yes" description="A visual container with a scrollbar allowing for content height that exceeds the display area">
 
 		<overview>
 
-			<p>The scrollpane widget provides a container and a scrollbar. The scrollbar can be used to move up and down in the container, so more content can be placed in the container than can be normally viewed at one time.</p>
+			<p>The scrollpane widget provides a container and a scrollbar.  The scrollbar can be used to move up and down in the container, so more content can be placed in the container than can be normally viewed at one time.</p>
 
 			<p>The scrollbar includes a draggable thumb as well as up and down arrows at the top and bottom.  Clicking the arrows scrolls the content of the container up or down by a small amount, whereas clicking on the scrollbar itself above or below the thumb will scroll the area by a large amount.</p>
 
@@ -3353,28 +3269,22 @@ $Version=2$
 
 		<properties>
 
-		    <property name="background" type="string" subtype="image">A background image to be placed behind the scrollpane.</property>
+			<property name="background" type="string" subtype="image">A background image to be placed behind the scrollpane.</property>
 
-		    <property name="bgcolor" type="string" subtype="color">A color, RGB or named, to be used as the scrollpane background.If neither bgcolor transparent.</property>
+			<property name="bgcolor" type="string" subtype="color">A color, RGB or named, to be used as the scrollpane background.If neither bgcolor transparent.</property>
 
-		    <property name="height" type="integer">height, in pixels, of the scrollpane's visible area. Due to the nature of the  can time.</property>
+			<property name="height" type="integer">height, in pixels, of the scrollpane's visible area.  Due to the nature of the can time.</property>
 
-		    <property name="visible" type="boolean">allows user to set scroll pane to visible (true) or not (false).</property>
+			<property name="visible" type="boolean">allows user to set scroll pane to visible (true) or not (false).</property>
 
-		    <property name="width" type="integer">width, in pixels, of the scrollpane, including the scrollbar area on the right side.</property>
+			<property name="width" type="integer">width, in pixels, of the scrollpane, including the scrollbar area on the right side.</property>
 
-		    <property name="x" type="integer">x-coordinate of the upper left corner of the scrollpane, relative to its container.</property>
+			<property name="x" type="integer">x-coordinate of the upper left corner of the scrollpane, relative to its container.</property>
 
-		    <property name="y" type="integer">y-coordinate of the upper left corner of the scrollpane, relative to its container.</property>
+			<property name="y" type="integer">y-coordinate of the upper left corner of the scrollpane, relative to its container.</property>
 
 		</properties>
-		
-		<actions>
-		
-			<action name="ScrollTo">Scrolls to a specific location determined by the scroll bar.</action>
-		
-		</actions>
-		
+
 		<events>
 		
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
@@ -3382,19 +3292,24 @@ $Version=2$
 			<event name="MouseMove">This event occurs when the user moves the mouse pointer while it is over the widget.  The event will repeatedly fire each time the pointer moves.</event>
 
 			<event name="MouseOut">This event occurs when the user moves the mouse pointer off of the widget.</event>
-			
+
 			<event name="MouseOver">This event occurs when the user first moves the mouse pointer over the widget.  It will not occur again until the user moves the mouse off of the widget and then back over it again.</event>
 
 			<event name="MouseUp">This event occurs when the user releases the mouse button on the widget.</event>
-			
-			<note>The Click, Wheel, MouseDown, and MouseUp events provide several pieces of useful information, including :shiftKey, :ctrlKey, :altKey, and :metaKey, which are 1 if the respective key is held down and 0 otherwise. These events also provide :button, a number representing the button number that the user used to execute the event (which appears to always be 0 for wheel).</note>
+
+			<note>The Click, Wheel, MouseDown, and MouseUp events provide several pieces of useful information, including :shiftKey, :ctrlKey, :altKey, and :metaKey, which are 1 if the respective key is held down and 0 otherwise.  These events also provide :button, a number representing the button number that the user used to execute the event (which appears to always be 0 for wheel).</note>
 
 		</events>
-		
-		
+
+		<actions>
+
+			<action name="ScrollTo">Scrolls to a specific location determined by the scroll bar.  Specify the 'Percent' attribute to indicate how far to scroll in decimal representation (so 1.00 is 100%, aka. the bottom of the page).  Specify 'Offset' how many pixels the content should be offset from the top (specify 100 to scroll the first 100 px of content off the top of the scroll pane).  Specify 'RangeStart' and 'RangeEnd' to scroll to within the pixel range (using the same units as offset).  Keep in mind that this action will trigger a scroll event to occur.</action>
+
+		</actions>
+
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -3430,17 +3345,18 @@ MyScrollPane "widget/scrollpane"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="tab" type="widget/tab" visual="yes" formelement="no" container="yes" description="A tab (or notebook) widget allowing multiple pages to be layered and individually selected for viewing">
 
 		<overview>
 
-			<p>The TabControl widget provides a DHTML tab control within Centrallix. The widget behaves in the same way as tab controls in other GUI environments, providing a set of tab pages, layered one on top of the other, which can be selected (brought to the foreground) by clicking the mouse on the respective visible tab at the top of the tab control.</p>
+			<p>The TabControl widget provides a DHTML tab control within Centrallix.  The widget behaves in the same way as tab controls in other GUI environments, providing a set of tab pages, layered one on top of the other, which can be selected (brought to the foreground) by clicking the mouse on the respective visible tab at the top of the tab control.</p>
 
 			<p>To further distinguish which tab at the top of the tab control is active, this widget slightly modifies the X/Y position of the tab as well as changing a thumbnail image (on the left edge of the tab) to further enhance the distinction between selected and inactive tab pages.</p>
 
@@ -3450,7 +3366,7 @@ MyScrollPane "widget/scrollpane"
 
 			<p>The tab pages are containers, and as such, controls of various kinds, including other tab controls, can be placed inside the tab pages.</p>
 
-			<p>Tab pages are added to a tab control by including widgets of type "widget/tabpage" within the "widget/tab" widget in the structure file that defines the application. Any controls to appear inside a particular tab page should be placed inside their respective "widget/tabpage" widgets in the structure file.Only widgets of type "widget/tabpage" should be placed inside a "widget/tab", with the exception of nonvisuals such as connectors.</p>
+			<p>Tab pages are added to a tab control by including widgets of type "widget/tabpage" within the "widget/tab" widget in the structure file that defines the application.  Any controls to appear inside a particular tab page should be placed inside their respective "widget/tabpage" widgets in the structure file.Only widgets of type "widget/tabpage" should be placed inside a "widget/tab", with the exception of nonvisuals such as connectors.</p>
 
 			<p>Tab pages also have a 'visible' property which allows them to be hidden and revealed.  This is used if the type is set to dynamic, but can be used manually as well.</p>
 
@@ -3458,95 +3374,95 @@ MyScrollPane "widget/scrollpane"
 
 		<properties>
 
-		    <property name="background" type="string" subtype="image">An image to be used as the background of the tab control.</property>
+			<property name="background" type="string" subtype="image">An image to be used as the background of the tab control.</property>
 
-		    <property name="bgcolor" type="string" subtype="color">As an alternate to "background", "bgcolor" can specify a color, either named or RGB.</property>
-		
+			<property name="bgcolor" type="string" subtype="color">As an alternate to "background", "bgcolor" can specify a color, either named or RGB.</property>
+
 			<property name="border_color" type="string">A color that outlines window.</property>
-			
+
 			<property name="border_radius" type="integer">A radius that describes the sharpness of the corners of the window (smaller means sharper).</property>
 
 			<property name="border_style" type="string">Determines the look of the outline.</property>
-			
-		    <property name="height" type="integer">The height, in pixels, of the tab control, including the page height but not including the height of the tabs at the top.</property>
 
-		    <property name="inactive_background" type="string" subtype="image">An image to be used as the background of the tabs which are inactive (in the background).</property>
+			<property name="height" type="integer">The height, in pixels, of the tab control, including the page height but not including the height of the tabs at the top.</property>
 
-		    <property name="inactive_bgcolor" type="string" subtype="color">As an alternate to "inactive_background", "inactive_bgcolor" can specify a color, either named or RGB.</property>
+			<property name="inactive_background" type="string" subtype="image">An image to be used as the background of the tabs which are inactive (in the background).</property>
+
+			<property name="inactive_bgcolor" type="string" subtype="color">As an alternate to "inactive_background", "inactive_bgcolor" can specify a color, either named or RGB.</property>
 
 			<property name="shadow_angle" type="integer">The placement of the shadow described as a rotational transformation with respect to the window.</property>
-			
+
 			<property name="shadow_color" type="string">The color of the shadow.</property>
 
 			<property name="shadow_offset" type="integer">The placement of the shadow with respect to the window.</property>
 
 			<property name="shadow_radius" type="integer">A radius that describes the sharpness of the corners of the shadow (smaller means sharper).</property>
 
-		    <property name="tab_location" type="string">The location of the tabs:  "top" (default), "bottom", "left", "right", or "none".</property>
+			<property name="tab_location" type="string">The location of the tabs: "top" (default), "bottom", "left", "right", or "none".</property>
 
 		    <property name="tab_width" type="integer">The width of the tabs in pixels.  This is optional for tab_locations of "top", "bottom", and "none".</property>
 
-		    <property name="textcolor" type="string" subtype="color">The color of the text to be used on the tabs to identify them.</property>
-			
-		    <property name="visible" type="boolean">allows user to set tab to visible (true) or not (false).</property>
+			<property name="textcolor" type="string" subtype="color">The color of the text to be used on the tabs to identify them.</property>
 
-		    <property name="width" type="integer">Width, in pixels, of the tab control, including the page width but not the width of the tabs (if they are at the side).</property>
+			<property name="visible" type="boolean">allows user to set tab to visible (true) or not (false).</property>
 
-		    <property name="x" type="integer">X-coordinate of the upper left corner of the tab control, relative to the container.</property>
+			<property name="width" type="integer">Width, in pixels, of the tab control, including the page width but not the width of the tabs (if they are at the side).</property>
 
-		    <property name="y" type="integer">Y-coordinate of the upper left corner of the control, relative to its container.</property>
+			<property name="x" type="integer">X-coordinate of the upper left corner of the tab control, relative to the container.</property>
+
+			<property name="y" type="integer">Y-coordinate of the upper left corner of the control, relative to its container.</property>
 
 		</properties>
 
+		<clientprops>
+
+			<clientprop name="selected" type="string">The name of the tab page that should be initially selected.  This can also contain a dynamic runclient() expression controlling which tab page is selected.</clientprop>
+
+			<clientprop name="selected_index" type="integer">Similar to "selected", but selects the tab by numeric index.</clientprop>
+
+		</clientprops>
+
 		<children>
 
-		    <child type="any">
+			<child type="any">
 
-			    <childproperty name="fieldname" type="string">This is the fieldname from the objectsource that the tabpage will use for its title.</childproperty>
+				<childproperty name="fieldname" type="string">This is the fieldname from the objectsource that the tabpage will use for its title.</childproperty>
 
-			    <childproperty name="title" type="string">The name of the tab page, which appears in the tab at the top of the control.</childproperty>
+				<childproperty name="title" type="string">The name of the tab page, which appears in the tab at the top of the control.</childproperty>
 
-			    <childproperty name="type" type="string">If this is set to dynamic then the tabpage will act as an objectsource client, displaying zero or more tabs: one tab for each item in the replica with title set to the value of the fieldname.  In this way, a tab control can have a mix of dynamic tabs and static ones.</childproperty>
+				<childproperty name="type" type="string">If this is set to dynamic then the tabpage will act as an objectsource client, displaying zero or more tabs: one tab for each item in the replica with title set to the value of the fieldname.  In this way, a tab control can have a mix of dynamic tabs and static ones.</childproperty>
 
-			    <childproperty name="visible" type="integer">0 or 1.  Can contain a dynamic runclient() expression to control when the tab page is visible to the user.</childproperty>
+				<childproperty name="visible" type="integer">0 or 1.  Can contain a dynamic runclient() expression to control when the tab page is visible to the user.</childproperty>
 
-		    </child>
+			</child>
 
 		</children>
 
 		<events>
 
-		    <event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
+			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
-		    <event name="MouseMove">This event occurs when the user moves the mouse pointer while it is over the widget.  The event will repeatedly fire each time the pointer moves.</event>
+			<event name="MouseMove">This event occurs when the user moves the mouse pointer while it is over the widget.  The event will repeatedly fire each time the pointer moves.</event>
 
-		    <event name="MouseOut">This event occurs when the user moves the mouse pointer off of the widget.</event>
+			<event name="MouseOut">This event occurs when the user moves the mouse pointer off of the widget.</event>
 
-		    <event name="MouseOver">This event occurs when the user first moves the mouse pointer over the widget.  It will not occur again until the user moves the mouse off of the widget and then back over it again.</event>
+			<event name="MouseOver">This event occurs when the user first moves the mouse pointer over the widget.  It will not occur again until the user moves the mouse off of the widget and then back over it again.</event>
 
-		    <event name="MouseUp">This event occurs when the user releases the mouse button on the widget.</event>
+			<event name="MouseUp">This event occurs when the user releases the mouse button on the widget.</event>
 
 			<event name="TabChanged">This event occurs when the visible tab changes.</event>
-			
-		</events>
-		
-		<clientprops>
-		
-		    <clientprop name="selected" type="string">The name of the tab page that should be initially selected.  This can also contain a dynamic runclient() expression controlling which tab page is selected.</clientprop>
 
-		    <clientprop name="selected_index" type="integer">Similar to "selected", but selects the tab by numeric index.</clientprop>
-		
-		</clientprops>
-		
+		</events>
+
 		<actions>
-		
+
 			<action name="SetTab">Sets the selected tab according to the parameter given (the tab itself or its index).</action>
-		
+
 		</actions>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -3568,11 +3484,12 @@ myTabControl "widget/tab"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
+
 
 	<widget name="table" type="widget/table" visual="yes" formelement="no" container="no" description="A visual widget providing a columnar presentation of multiple objects of the same type (such as query result records).">
 
@@ -3588,7 +3505,7 @@ myTabControl "widget/tab"
 
 		<usage>
 
-			<p>Table widgets are normally placed inside of a scrollpane so that any rows which don't fit int the container can still be viewed. Table columns are created via "widget/table-column" child widgets within the table widget.</p>
+			<p>Table widgets are normally placed inside of a scrollpane so that any rows which don't fit int the container can still be viewed.  Table columns are created via "widget/table-column" child widgets within the table widget.</p>
 
 		</usage>
 
@@ -3596,7 +3513,7 @@ myTabControl "widget/tab"
 
 			<property name="allow_selection" type="yes/no">Whether to permit the user to select rows in the table.  Default "yes".</property>
 
-			<property name="background" type="string">A background image for the table. This "shows through" between table cells.</property>
+			<property name="background" type="string">A background image for the table.  This "shows through" between table cells.</property>
 
 			<property name="bgcolor" type="string">A color, RGB or named, to be used between table cells and rows.If neither bgcolor nor background are specified, the table is transparent.</property>
 
@@ -3606,10 +3523,12 @@ myTabControl "widget/tab"
 
 			<property name="colsep" type="integer">The width of the column separation lines in pixels.  Default is 1.</property>
 
+			<property name="colsep_mode" type="string">Either 'full' or 'header'.  Default is 'full'.</property>
+
 			<property name="data_mode" type="string">Either "rows" (default) or "properties".  In "properties" mode, the table displays one row per attribute, and so only displays the current record in the objectsource.  In "rows" mode, the table displays one row per record in the objectsource.</property>
 
 			<property name="demand_scrollbar" type="integer">Acts as a boolean to only show the scrollbar when it is needed (activates when it is set to "1").</property>
-			
+
 			<property name="dragcols" type="integer">Whether to allow dragging of column boundaries to resize columns; set to 1 to allow it and 0 to disallow.  Default is 1.</property>
 
 			<property name="followcurrent" type="yes/no">Set to 'yes' to cause the table's current row to follow the currently selected object in the ObjectSource, and 'no' to disable this behavior.  Default is 'yes'.</property>
@@ -3621,21 +3540,21 @@ myTabControl "widget/tab"
 			<property name="hdr_bgcolor" type="string">A color, RGB or named, for the header row cells.</property>
 
 			<property name="hide_scrollbar" type="integer">Acts as a boolean to determine if the scrollbar can be seen (hide is "1").</property>
-			
+
 			<property name="height" type="integer">The height in pixels of the table.</property>
 
 			<property name="image_max_height" type="integer">The maximum height of the image from the child.</property>
-			
+
 			<property name="image_max_width" type="integer">The maximum width of the image from the child.</property>
-			
+
 			<property name="initial_selection" type="string">Sets which data element in the table has focus initially.</property>
-			
-			<property name="inner_border" type="integer">width of the inner spacing between cells in a table. Default0.</property>
+
+			<property name="inner_border" type="integer">width of the inner spacing between cells in a table.  Default0.</property>
 
 			<property name="inner_padding" type="integer">margins within each cell, in pixels.  Default is 0 pixels.</property>
-			
+
 			<property name="max_rowheight" type="integer">The maximum height of each row.</property>
-			
+
 			<property name="min_rowheight" type="integer">The minimum height of each row.</property>
 
 			<property name="newrow_background" type="string">A background image for the "new row" placeholder that is visible when a new object is being created.</property>
@@ -3643,13 +3562,13 @@ myTabControl "widget/tab"
 			<property name="newrow_bgcolor" type="string">A color, RGB or named, for the "new row" placeholder that is visible when a new object is being created.</property>
 
 			<property name="objectsource" type="string">Identifies the OSRC that the table connects to.</property>
-			
+
 			<property name="outer_border" type="integer">width of the outer spacing around the outside of the table, in pixels.  Default0.</property>
-		
+
 			<property name="overlap_scrollbar" type="integer">Acts as a boolean to allow the scroll bar to overlab with the table (allow is "1").</property>
-	
+
 			<property name="reverse_order" type="integer">Acts as a boolean to reverse to order of the table elements (reverses if set to "1").</property>
-		
+
 			<property name="row1_background" type="string">A background image for the table row cells.</property>
 
 			<property name="row1_bgcolor" type="string">A color, RGB or named, for the table row cells.</property>
@@ -3657,11 +3576,11 @@ myTabControl "widget/tab"
 			<property name="row2_background" type="string">A background image for the table row cells.  If this is specified, rows will alternate in backgrounds between "row_background1" and "row_background2".</property>
 
 			<property name="row2_bgcolor" type="string">A color, RGB or named, for the table row cells.  If this is specified, rows will alternate in colors between "row_bgcolor1" and "row_bgcolor2".</property>
-			
+
 			<property name="row_border_color" type="string">Determines the color of the edge of the rows.</property>
-			
+
 			<property name="row_border_radius" type="string">Determines the sharpness of the row corners, smaller is more sharp.</property>
-			
+
 			<property name="rowcashe_size" type="integer">How many rows are shown in the table.</property>
 
 			<property name="rowheight" type="integer">The height of the individual rows in pixels.  Default is 15 pixels.</property>
@@ -3671,11 +3590,11 @@ myTabControl "widget/tab"
 			<property name="rowhighlight_bgcolor" type="string">A color, RGB or named, for the current (selected) row cells.</property>
 
 			<property name="row_shadow_color" type="string">The color of the shadow of the row.</property>
-			
+
 			<property name="row_shadow_offset" type="integer">How far the shadow is from the row.</property>
-			
+
 			<property name="row_shadow_radius" type="integer">The sharpness of the corners of the shadow, smaller means more sharp.</property>
-			
+
 			<property name="show_selection" type="yes/no">Whether to highlight the currently selected row.  Default "yes".</property>
 
 			<property name="textcolor" type="string">A color, RGB or named, of the text in the normal data rows.</property>
@@ -3692,9 +3611,9 @@ myTabControl "widget/tab"
 
 			<property name="windowsize" type="integer">The maximum number of rows to show at any given time, for dynamic tables.</property>
 
-			<property name="x" type="integer">X-coordinate of the upper left corner of the table. Default is 0.</property>
+			<property name="x" type="integer">X-coordinate of the upper left corner of the table.  Default is 0.</property>
 
-			<property name="y" type="integer">Y-coordinate of the upper left corner of the table. Default is 0.</property>
+			<property name="y" type="integer">Y-coordinate of the upper left corner of the table.  Default is 0.</property>
 
 		</properties>
 
@@ -3702,16 +3621,16 @@ myTabControl "widget/tab"
 
 			<child type="widget/table-column">
 
-				<childproperty name="align" type="string">The alignment of the column:  "left" or "right".</childproperty>
+				<childproperty name="align" type="string">The alignment of the column: "left" or "right".</childproperty>
 
 				<childproperty name="caption_fieldname" type="string">It is a pseudonym for the fieldname.</childproperty>
-				
+
 				<childproperty name="caption_textcolor" type="string">The color of the caption_fieldname.</childproperty>
-				
+
 				<childproperty name="group_by" type="string">Acts as a boolean to determine if items are group able.</childproperty>
-				
+
 				<childproperty name="height" type="integer">The height in pixels of the column.</childproperty>
-				
+
 				<childproperty name="title" type="string">The title of the column to be displayed in the header row.</childproperty>
 
 				<childproperty name="type" type="string">The type of the column: "text", "check", or "image".  "text" is a normal column, and displays the textual value of the data element.  "check" displays a checkmark if the data is non-zero (integers) or for strings if the value is non-empty and not "N" or "No".  "image" displays the image referred to by the pathname contained in the data value.</childproperty>
@@ -3719,7 +3638,7 @@ myTabControl "widget/tab"
 				<childproperty name="width" type="integer">width of the column.</childproperty>
 
 				<childproperty name="wrap" type="string">Determines if text can wrap around an obstacle.</childproperty>
-				
+
 			</child>
 
 		</children>
@@ -3731,18 +3650,18 @@ myTabControl "widget/tab"
 			<event name="DblClick">The DblClick event fires when the user double-clicks the mouse on a row.  Passes three values, 'Caller' which is the table's name, 'recnum' which is the sequential number of the record in the table, and 'data' which is an array of the data in the selected record.</event>
 
 			<event name="RightClick">The Click event fires when a user right clicks on a mouse or mouse pad.</event>
-			
+
 		</events>
 
 		<actions>
-		
+
 			<action name="Clear">Drops all elements from the table.</action>
 
 		</actions>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -3778,61 +3697,48 @@ tblFileList "widget/table"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="template" type="widget/template" visual="no" formelement="no" container="no" description="templates are a way to provide default values (and default children) of different widget_class's">
 
-		<overview>
-
-		</overview>
+		<overview> </overview>
 
 		<usage>
 
-		  <p>A widget/template must be a root widget of a file (which normally is given a .tpl extension). </p>
+			<p>A widget/template must be a root widget of a file (which normally is given a .tpl extension).  </p>
 
-		  <p>Each child in a widget/template is a "rule". Each rule applies to widgets that both 1) have the same 'widget_class' property value (there can be only one widget_class per widget (and "rule")) and 2) match the widget type of the child (eg "widget/imagebutton").</p>
+			<p>Each child in a widget/template is a "rule".  Each rule applies to widgets that both 1) have the same 'widget_class' property value (there can be only one widget_class per widget (and "rule")) and 2) match the widget type of the child (eg "widget/imagebutton").</p>
 
-		  <p>Every other property of the "rule" are default values.</p>
+			<p>Every other property of the "rule" are default values.</p>
 
-		  <p>All children of the "rule" are automatically inserted into the matched widgets.</p>
+			<p>All children of the "rule" are automatically inserted into the matched widgets.</p>
 
 		</usage>
 
 		<properties>
 
-			<property name="" type=""/>
+			<property name="" type="" />
 
 		</properties>
 
 		<children>
 
-		  <child type="any">
+			<child type="any">
 
-		    <childproperty name="widget_class" type="string">The value of this property must match another widget before said widget will "inherit" this "rule".</childproperty>
+				<childproperty name="widget_class" type="string">The value of this property must match another widget before said widget will "inherit" this "rule".</childproperty>
 
-		  </child>
+			</child>
 
 		</children>
 
-		<events>
-
-		</events>
-
-		<actions>
-
-		</actions>
-
-		<clientprops>
-
-		</clientprops>
-
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 objcanvas_test "widget/template"
 
@@ -3866,11 +3772,12 @@ objcanvas_test "widget/template"
 
     }
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
+
 
 	<widget name="textarea" type="widget/textarea" description="Visual multi-line text data entry widget." visual="yes" formelement="yes" container="no">
 
@@ -3895,13 +3802,13 @@ objcanvas_test "widget/template"
 			<property name="fieldname" type="string">The field in the objectsource to associate this textarea with.</property>
 
 			<property name="form" type="string">Links text area to a form.</property>
-			
+
 			<property name="height" type="integer">The height of the textarea, in pixels</property>
 
 			<property name="maxchars" type="integer">The maximum number of characters the textarea should accept from the user</property>
 
 			<property name="mode" type="string">Can hold text, html, or wiki and display.</property>
-			
+
 			<property name="readonly" type="yes/no">Set to 'yes' if the data in the text area should be viewed only and not be modified.</property>
 
 			<property name="style" type="string">The border style of the text area, can be 'raised' or 'lowered'.  Default is 'raised'.</property>
@@ -3914,14 +3821,10 @@ objcanvas_test "widget/template"
 
 		</properties>
 
-		<children>
-
-		</children>
-
 		<events>
-			
+
 			<event name="BeforeKeyPress">This event occurs before the key press event is fired and can stop the key press event.</event>
-			
+
 			<event name="DataChange">This event occurs when the user has modified the data value of the widget (clicked or unclicked it).</event>
 
 			<event name="DataModify">This event occurs when the data is changed (occurs when key press or button changes things).</event>
@@ -3931,7 +3834,7 @@ objcanvas_test "widget/template"
 			<event name="GetFocus">This event occurs when the editbox receives keyboard focus (if the user tabs on to it or clicks on it, for instance).</event>
 
 			<event name="KeyPress">This event occurs when the user presses any key.</event>
-			
+
 			<event name="LoseFocus">This event occurs when the editbox loses keyboard focus (if the user tabs off of it, for instance).</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
@@ -3951,34 +3854,23 @@ objcanvas_test "widget/template"
 		<actions>
 
 			<action name="InsertText">Checks to see if things need to be changed (new is different from old) then calls set value.</action>
-			
+
 			<action name="SetFocus">Sets the focus on a selected widget.</action>
-			
+
 			<action name="SetValue">Sets the content to the text parameter sent.</action>
-		
+
 		</actions>
 
-		<clientprops>
-
-		</clientprops>
-
-		<sample>
-
-		<![CDATA[
-
-		]]>
-
-		</sample>
-
 	</widget>
+
 
 	<widget name="textbutton" type="widget/textbutton" visual="yes" container="no" formelement="no" description="A simple visual button widget built not from images but from a simple text string.">
 
 		<overview>
 
-			<p>A textbutton provides similar functionality to the imagebutton. However, the programmer need not create two or three graphics images in order to use a textbutton; rather simply specifying the text to appear on the button is sufficient.</p>
+			<p>A textbutton provides similar functionality to the imagebutton.  However, the programmer need not create two or three graphics images in order to use a textbutton; rather simply specifying the text to appear on the button is sufficient.</p>
 
-			<p>Textbuttons, like imagebuttons, can either have two or three states. A three-state textbutton doesn't have a "raised" border until the user points to it, whereas a two-state textbutton retains its raised border whether pointed to or not.</p>
+			<p>Textbuttons, like imagebuttons, can either have two or three states.  A three-state textbutton doesn't have a "raised" border until the user points to it, whereas a two-state textbutton retains its raised border whether pointed to or not.</p>
 
 		</overview>
 
@@ -3989,19 +3881,19 @@ objcanvas_test "widget/template"
 		</usage>
 
 		<properties>
-		
+
 			<property name="align" type="string">Sets the alignment of text in the button, can have left right or center (default).</property>
 
 			<property name="background" type="string">A background image for the button.</property>
 
 			<property name="bgcolor" type="string">A color, RGB or named, to be used as the button's background.If neither bgcolor nor background are specified, the button is transparent.</property>
-		
+
 			<property name="border_color" type="string">A color that outlines the button.</property>
-			
+
 			<property name="border_radius" type="integer">A radius that describes the sharpness of the corners of the button (smaller means sharper).</property>
 
 			<property name="border_style" type="string">Determines the look of the outline.</property>
-			
+
 			<property name="disable_color" type="string">A color, RGB or named, to be used for the button's text when it is disabled.</property>
 
 			<property name="enabled" type="yes/no or expr">Whether the button is enabled (can be clicked).  Default is 'yes'.  Also supports dynamic runclient() expressions allowing the enabled status of the button to follow the value of an expression.</property>
@@ -4013,18 +3905,18 @@ objcanvas_test "widget/template"
 			<property name="height" type="integer">Height, in pixels, of the text button.</property>
 
 			<property name="image" type="string">File path to the source of the image.</property>
-			
+
 			<property name="image_height" type="integer">Defines the height of image.</property>
-			
+
 			<property name="image_margin" type="integer">Defines spacing between image and the border.</property>
-			
+
 			<property name="image_width" type="integer">Defines the width of image.</property>
-			
+
 			<property name="image_position" type="string">Describes where an image is in the text button (top-default, right, bottom, left).</property>
-			
+
 			<property name="text" type="string">The text to appear on the button.  This may be a dynamic runclient() expression to dynamically change the button's text.</property>
 
-			<property name="tristate" type="yes/no">Whether or not the button is tri-state (does not display a raised border until the user points at it). Default is yes.</property>
+			<property name="tristate" type="yes/no">Whether or not the button is tri-state (does not display a raised border until the user points at it).  Default is yes.</property>
 
 			<property name="width" type="integer">The width, in pixels, of the text button.</property>
 
@@ -4034,13 +3926,9 @@ objcanvas_test "widget/template"
 
 		</properties>
 
-		<children>
-
-		</children>
-
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the button. No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the button.  No parameters are available from this event.</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
@@ -4062,7 +3950,7 @@ objcanvas_test "widget/template"
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -4084,53 +3972,54 @@ MyButton "widget/textbutton"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="timer" type="widget/timer" visual="no" formelement="no" container="no" description="A nonvisual widget which is used to fire an event when a period of time has elapsed.">
 
 		<overview>
 
-			<p>A timer widget is used to schedule an Event to occur after a specified amount of time.  Timers can be set to expire a set amount of time after the page is loaded, or they can be triggered into counting down via activating an Action on the timer. Timers can be used to create animations, delayed effects, and more.</p>
+			<p>A timer widget is used to schedule an Event to occur after a specified amount of time.  Timers can be set to expire a set amount of time after the page is loaded, or they can be triggered into counting down via activating an Action on the timer.  Timers can be used to create animations, delayed effects, and more.</p>
 
 		</overview>
 
 		<usage>
 
-			<p>Timers are nonvisual widgets which can be placed almost anywhere in an application.  They are most commonly found at the top-level of the application, however. Timers have no direct effects on the object in which they are placed.  Timers can only contain Connector widgets.</p>
+			<p>Timers are nonvisual widgets which can be placed almost anywhere in an application.  They are most commonly found at the top-level of the application, however.  Timers have no direct effects on the object in which they are placed.  Timers can only contain Connector widgets.</p>
 
 		</usage>
 
 		<properties>
 
-		    <property name="auto_reset" type="boolean">The timer starts counting down again immediately after it expires.</property>
+			<property name="auto_reset" type="boolean">The timer starts counting down again immediately after it expires.</property>
 
-		    <property name="auto_start" type="boolean">The timer starts counting down immediately after the page loads.</property>
+			<property name="auto_start" type="boolean">The timer starts counting down immediately after the page loads.</property>
 
-		    <property name="msec" type="integer">Of milliseconds (1/1000th of a second) before the timer expires.</property>
+			<property name="msec" type="integer">Of milliseconds (1/1000th of a second) before the timer expires.</property>
 
 		</properties>
 
+		<events>
+
+			<event name="expire">This occurs when the timer hits its timeout and the auto reset is not enabled.</event>
+
+		</events>
+
 		<actions>
 
-		    <action name="CancelTimer">Actions causes a timer to stop counting down, and thus no Expire event will occur until another countdown sequence is initiated by a SetTimer action.</action>
+			<action name="CancelTimer">Actions causes a timer to stop counting down, and thus no Expire event will occur until another countdown sequence is initiated by a SetTimer action.</action>
 
-		    <action name="SetTimer">Action takes two parameters: "Time" (integer in milliseconds) and "AutoReset" (integer 0 or 1). It causes a timer to begin counting down towards an Expire event.</action>
+			<action name="SetTimer">Action takes two parameters: "Time" (integer in milliseconds) and "AutoReset" (integer 0 or 1).  It causes a timer to begin counting down towards an Expire event.</action>
 
 		</actions>
-		
-		<events>
-		
-			<event name="expire">This occurs when the timer hits its timeout and the auto reset is not enabled.</event>
-		
-		</events>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -4186,63 +4075,64 @@ mytimerTwo "widget/timer"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="treeview" type="widget/treeview" visual="yes" formelement="no" container="no" description="A visual widget used to display tree-structured data (such as a directory tree or similar).">
 
 		<overview>
 
-			<p>A treeview provides a way of viewing hierarchically-organized data via a "traditional" GUI point-and-click tree structure. A treeview has "branches" that can expand and collapse entire subtrees of data.</p>
+			<p>A treeview provides a way of viewing hierarchically-organized data via a "traditional" GUI point-and-click tree structure.  A treeview has "branches" that can expand and collapse entire subtrees of data.</p>
 
-			<p>Centrallix treeviews present a subtree of the ObjectSystem, with the data dynamically loaded, on demand, from the server as the widget is used. The treeview widget thus has no intelligence in and of itself in determining what kinds of objects are presented at each level of the tree. Many times, this is exactly what is desired because the treeview is being used to simply browse objects in the ObjectSystem, such as directories and files. In other cases, the treeview is teamed up with a special ObjectSystem object called a "querytree" (QYT) object. The querytree object creates a hierarchical view from other potentially non-hierarchical data in the ObjectSystem, such as that from different database tables and so forth.</p>
+			<p>Centrallix treeviews present a subtree of the ObjectSystem, with the data dynamically loaded, on demand, from the server as the widget is used.  The treeview widget thus has no intelligence in and of itself in determining what kinds of objects are presented at each level of the tree.  Many times, this is exactly what is desired because the treeview is being used to simply browse objects in the ObjectSystem, such as directories and files.  In other cases, the treeview is teamed up with a special ObjectSystem object called a "querytree" (QYT) object.  The querytree object creates a hierarchical view from other potentially non-hierarchical data in the ObjectSystem, such as that from different database tables and so forth.</p>
 
 		</overview>
 
 		<usage>
 
-			<p>Treeviews can be placed inside of any visual container, but are usually placed inside of a scrollpane, since scrollpanes can expand to allow the user to view data that would not normally fit inside the desired container. Treeviews can contain only nonvisual widgets such as connectors.</p>
+			<p>Treeviews can be placed inside of any visual container, but are usually placed inside of a scrollpane, since scrollpanes can expand to allow the user to view data that would not normally fit inside the desired container.  Treeviews can contain only nonvisual widgets such as connectors.</p>
 
 		</usage>
 
 		<properties>
 
-		    <property name="fgcolor" type="string">A color, RGB or named, to be used for the text for the items in the treeview.</property>
+			<property name="fgcolor" type="string">A color, RGB or named, to be used for the text for the items in the treeview.</property>
 
-		    <property name="highlight_background" type="string">A background image for the selected item in the treeview.</property>
+			<property name="highlight_background" type="string">A background image for the selected item in the treeview.</property>
 
-		    <property name="highlight_fgcolor" type="string">A color, RGB or named, to be used for the text for the selected item.</property>
+			<property name="highlight_fgcolor" type="string">A color, RGB or named, to be used for the text for the selected item.</property>
 
-		    <property name="icon" type="string">A pathname to an image to be used as icons for the items in the treeview.</property>
+			<property name="icon" type="string">A pathname to an image to be used as icons for the items in the treeview.</property>
 
 			<property name="order" type="string">Orders treeview in descending (desc) and ascending (anything else) order.</property>
-			
-		    <property name="show_branches" type="yes/no">Whether to display the connections between items in the tree using lines.</property>
 
-		    <property name="show_root" type="yes/no">Whether to display the root of the tree.  If "no", then the root is auto-expanded and only its children are visible.</property>
+			<property name="show_branches" type="yes/no">Whether to display the connections between items in the tree using lines.</property>
 
-		    <property name="show_root_branch" type="yes/no">Whether to display the connection lines between the root and the root's immediate children.  If "no", the root's children are flush against the lefthand side of the treeview, otherwise the connecting lines show up.</property>
+			<property name="show_root" type="yes/no">Whether to display the root of the tree.  If "no", then the root is auto-expanded and only its children are visible.</property>
 
-		    <property name="source" type="string" subtype="OSMLobject">The ObjectSystem path of the root of the treeview.</property>
+			<property name="show_root_branch" type="yes/no">Whether to display the connection lines between the root and the root's immediate children.  If "no", the root's children are flush against the lefthand side of the treeview, otherwise the connecting lines show up.</property>
 
-		    <property name="use_3d_lines" type="yes/no">If set to "yes", the branch lines are drawn in a 3D style, otherwise they are drawn in a single color.</property>
+			<property name="source" type="string" subtype="OSMLobject">The ObjectSystem path of the root of the treeview.</property>
 
-		    <property name="width" type="integer">Width, in pixels, of the treeview.</property>
+			<property name="use_3d_lines" type="yes/no">If set to "yes", the branch lines are drawn in a 3D style, otherwise they are drawn in a single color.</property>
 
-		    <property name="x" type="integer">X-coordinate of the upper left corner of the treeview's root object.</property>
+			<property name="width" type="integer">Width, in pixels, of the treeview.</property>
 
-		    <property name="y" type="integer">Y-coordinate of the upper left corner of the treeview's root object.</property>
+			<property name="x" type="integer">X-coordinate of the upper left corner of the treeview's root object.</property>
+
+			<property name="y" type="integer">Y-coordinate of the upper left corner of the treeview's root object.</property>
 
 		</properties>
 
 		<events>
 
 			<event name="Click">This event occurs when the user clicks while the treeview is in focus.</event>
-		
-		    <event name="ClickItem">Occurs when the user clicks on the clickable link for an item in the treeview. Its one parameter is "Pathname", or the ObjectSystem path to the object which was selected.</event>
+
+			<event name="ClickItem">Occurs when the user clicks on the clickable link for an item in the treeview.  Its one parameter is "Pathname", or the ObjectSystem path to the object which was selected.</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
@@ -4255,26 +4145,26 @@ mytimerTwo "widget/timer"
 			<event name="MouseUp">This event occurs when the user releases the mouse button on the widget.</event>
 
 			<event name="SelectItem">This event occurs when one of the elements of the treeview is given focus.</event>
-			
-		    <event name="RightClickItem">To the above, but when the user right-clicks on an item in the treeview.</event>
+
+			<event name="RightClickItem">To the above, but when the user right-clicks on an item in the treeview.</event>
 
 		</events>
-		
+
 		<actions>
 
 			<action name="Search">Searches for a specific element.</action>
-			
+
 			<action name="SearchNext">Returns the next element in the treeview.</action>
-			
+
 			<action name="SetFocus">Transfers focus to the selected element.</action>
-		
+
 			<action name="SetRoot">Sets the selected element as the root.</action>
 
 		</actions>
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -4310,11 +4200,12 @@ mypane "widget/pane"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
+
 
 	<widget name="variable" type="widget/variable" visual="no" formelement="no" container="no" description="A scalar variable object">
 
@@ -4332,7 +4223,7 @@ mypane "widget/pane"
 
 		<properties>
 
-		    <property name="fieldname" type="string">The field with which to link / connect to the variable.</property>
+			<property name="fieldname" type="string">The field with which to link / connect to the variable.</property>
 
 			<property name="form" type="string">The form (e.g. it's osrc) with which to associate the variable and fieldname (if different than the form in which variable is currently nested).</property>
 
@@ -4340,23 +4231,23 @@ mypane "widget/pane"
 
 		</properties>
 
-		<actions>
-
-		    <action name="SetValue">Called by a widget/connector: Sets the value of the variable to whatever is specified by the "Value" parameter.</action>
-
-		</actions>
-		
 		<events>
-			
+
 			<event name="DataChange">This event occurs when the user has modified the data value of the widget (clicked or unclicked it).</event>
 
 			<event name="DataModify">This event occurs when the data is changed (occurs when key press or button changes things).</event>
 
 		</events>
 
+		<actions>
+
+			<action name="SetValue">Called by a widget/connector: Sets the value of the variable to whatever is specified by the "Value" parameter.</action>
+
+		</actions>
+
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
 $Version=2$
 
@@ -4370,25 +4261,27 @@ counter "widget/variable"
 
 	}
 
-		]]>
+			]]>
 
 		</sample>
 
 	</widget>
 
+
 	<widget name="vbox" type="widget/vbox" description="Container which automatically positions its children" visual="yes" formelement="no" container="yes" osrcclient="no">
 
 		<overview>
 
-			<p>An autolayout widget with style set to "vbox".  See "widget/autolayout".</p>
+			<p>An autolayout widget with style set to "vbox". See "widget/autolayout".</p>
 
 		</overview>
-		
+
 		<usage>See "widget/autolayout"</usage>
 
-		<properties/>
+		<properties />
 
 	</widget>
+
 
 <!--
 
@@ -4438,9 +4331,9 @@ counter "widget/variable"
 
 		<sample>
 
-		<![CDATA[
+			<![CDATA[
 
-		]]>
+			]]>
 
 		</sample>
 

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -2389,6 +2389,61 @@ f_trx_mod_l "widget/label" { width=86; text="User Edit?"; align=right; font_size
 	</widget>
 
 
+	<widget name="map" type="widget/map" visual="yes" formelement="no" container="yes" description="A visual widget for displaying geographical maps.">
+
+		<overview>
+
+			<p>The map widget is a visual widget for displaying geographical maps, which are pulled from an object source.</p>
+
+		</overview>
+
+		<usage>
+
+			<p>The map widget is a visual that contains Centrallix objects.</p>
+
+		</usage>
+
+		<properties>
+
+			<property name="width" type="integer">Width (in pixels) of the map.</property>
+
+			<property name="x" type="integer">X-coordinate of the upper left corner of the map (in pixels), relative to its container.</property>
+
+			<property name="y" type="integer">Y-coordinate of the upper left corner of the map (in pixels), relative to its container.</property>
+
+			<property name="height" type="integer">Height (in pixels) of the map.</property>
+
+			<property name="source" type="string">A Centrallix object source path that we open to get the objects that will be rendered in the map widget.</property>
+
+			<property name="allow_selection" type="integer">Not implemented yet: Specify 1 to enable something... (default: 0)</property>
+
+			<property name="show_selection" type="integer">Not implemented yet: Specify 1 to enable something... (default: 0)</property>
+
+		</properties>
+
+		<events>
+
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
+
+			<event name="DblClick">This event occurs when the user double-clicks the mouse pointer (equivalent to two Click events occuring on the widget within a required time period) while it is over this widget.</event>
+
+			<event name="RightClick">The RightClick event occurs when a user clicks on the widget with the relevant button on their mouse or mouse pad.</event>
+
+			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
+
+			<event name="MouseMove">This event occurs when the user moves the mouse pointer while it is over the widget (or content inside the widget).  The event will repeatedly fire each time the pointer moves.</event>
+
+			<event name="MouseOut">This event occurs when the user moves the mouse pointer off of the widget.</event>
+
+			<event name="MouseOver">This event occurs when the user first moves the mouse pointer over the widget.  It will not occur again until the user moves the mouse off of the widget and then back over it again.</event>
+
+			<event name="MouseUp">This event occurs when the user releases the mouse button on the widget.</event>
+
+		</events>
+
+	</widget>
+
+
 	<widget name="menu" type="widget/menu" visual="yes" formelement="no" container="no" description="A visual pop-up or drop-down menu widget.">
 
 		<overview>

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -2070,7 +2070,13 @@ f_trx_mod "widget/checkbox"
 
 		<actions>
 
-			<action name="LoadPage">The LoadPage action takes two parameters.  "Source" contains the URL for the new page to be loaded into the HTML area.The optional parameter "Transition" indicates the type of fade to be used between one page and the next.Currently supported values are "pixelate", "rlwipe", and "lrwipe".</action>
+			<action name="LoadPage">Loads a new page into the HTML widget using two parameters.  The "Source" parameter specifies the URL for the new page to be loaded into the HTML area and the optional "Mode" parameter can specify a new value for the mode property.  The optional parameter "Transition" indicates the type of fade to be used between one page and the next.  This currently supports: rlwipe, lrwipe, and pixelate.</action>
+
+			<action name="AddText">Appends content from the specified "Text" string parameter to the end of the content in an HTML widget.  If the "ContentType" string parameter is specified with a value that differs from the current content type, all HTML content in the widget is overwritten.</action>
+
+			<action name="SetValue">Replaces the current HTML content with the specified "Value" (or clears it if no Value is specified), and sets the current content type using the "ContentType" string parameter, if it is specified (otherwise, the previous content type is preserved).</action>
+
+			<action name="ShowText">Causes plain text content in the widget to be escaped properly so it can be shown using HTML, protecting from cross-site scripting attacks.  This action takes no parameters.</action>
 
 		</actions>
 
@@ -2543,13 +2549,19 @@ f_trx_mod_l "widget/label" { width=86; text="User Edit?"; align=right; font_size
 
 			<event name="MouseUp">This event occurs when the user releases the mouse button on the checkbox.</event>
 
-			<event name="Select">This event fires when a menu item is selected.  It can be placed in the menu itself, or inside the menu item widget.  When on a menu item, it only fires when that item is selected.  When on a menu, it passes the selected item's value as a parameter named 'Item' (string).</event>
+			<event name="Select">This event fires when a menu item is selected.  It can be placed in the menu itself, or inside the menu item widget.  When on a menu item, it only fires when that item is selected.  When on a menu, it passes the selected item's value as a parameter named 'Item' (string).  This event also provides the "Value" and "Label" parameters to represent what was selected.</event>
+
+			<event name="SelectItem">This event occurs when an item in the menu is selected.  It provides the same parameters as the Select event.</event>
+
+			<event name="Activate">This event occurs when the dropdown appears.  It provides two parameters, "X" and "Y", which are the the (integer) positions (in pixels) on the page for the menu has appeared.</event>
+
+			<event name="Deactivate">This event occurs when the dropdown disappears, and it provides no parameters.</event>
 
 		</events>
 
 		<actions>
 
-			<action name="Activate">This action causes a popup-type menu to become visible and appear at a selected (x,y) position on the page.  When the user selects an item on the menu or clicks elsewhere on the page, the menu then disappears.  Takes two parameters - X and Y, the (integer) positions on the page for the menu to appear.</action>
+			<action name="Popup">This action causes a popup-type menu to become visible and appear at a selected (x,y) position on the page.  When the user selects an item on the menu or clicks elsewhere on the page, the menu then disappears.  Takes two parameters - "X" and "Y", which are the (integer) positions (in pixels) on the page for the menu to appear.</action>
 
 		</actions>
 
@@ -3888,6 +3900,8 @@ myTabControl "widget/tab"
 
 			<action name="Clear">Drops all elements from the table.</action>
 
+			<action name="ShowSelection">Enables the initial_selection property and redraws the table.</action>
+
 		</actions>
 
 		<sample>
@@ -4179,6 +4193,12 @@ objcanvas_test "widget/template"
 
 			<action name="SetText">Called from a connector, this action sets the button's text to the value passed in through connector's "Text" parameter.</action>
 
+			<action name="Click">Triggers a Click event on the textbutton with the "from_action" parameter set to 1.</action>
+
+			<action name="Disable">This action causes the textbutton to enter its disabled state, displaying the disable_color, if specified.</action>
+
+			<action name="Enable">This action causes the textbutton to enter its enabled state, possibly changing its normal colors.</action>
+
 		</actions>
 
 		<sample>
@@ -4238,7 +4258,7 @@ MyButton "widget/textbutton"
 
 		<events>
 
-			<event name="expire">This occurs when the timer hits its timeout and the auto reset is not enabled.</event>
+			<event name="Expire">This occurs when the timer hits its timeout and the auto reset is not enabled.</event>
 
 		</events>
 

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -1,101 +1,74 @@
-<?xml version='1.0'?>
+<?xml version='1.0' encoding="UTF-8"?>
 
 <!DOCTYPE widgets [
+	<!-- Define the widgets elements. -->
+	<!ELEMENT widgets (widget*)>
+	<!ELEMENT widget (
+		overview, usage, properties, clientprops?,
+		children?, events?, actions?, sample?
+	)>
+	
+	<!-- Define widget elements. -->
+	<!ELEMENT overview (#PCDATA | p | b | i | ul | ol)*>
+	<!ELEMENT usage (#PCDATA | p | b | i | ul | ol)*>
+	<!ELEMENT properties (property | note)*>
+	<!ELEMENT property (#PCDATA | ni)*>
+	<!ELEMENT clientprops (clientprop | note)*>
+	<!ELEMENT clientprop (#PCDATA | ni)*>
+	<!ELEMENT children (child | note)*>
+	<!ELEMENT child (childproperty | note)*>
+	<!ELEMENT childproperty (#PCDATA | ni)*>
+	<!ELEMENT events ((event | note)*)>
+	<!ELEMENT event (#PCDATA | ni)*>
+	<!ELEMENT actions (action | note)*>
+	<!ELEMENT action (#PCDATA | ni)*>
+	<!ELEMENT sample (#PCDATA)>
+	
+	<!-- Adds context for all properties/events/action/etc. -->
+	<!ELEMENT note (#PCDATA | ni)*>
+	
+	<!-- Define HTML elements -->
+	<!ELEMENT p (#PCDATA | b | i | ul | ol)*>
+	<!ELEMENT b (#PCDATA)*>
+	<!ELEMENT i (#PCDATA)*>
+	<!ELEMENT ul (li)*>
+	<!ELEMENT ol (li)*>
+	<!ELEMENT li (#PCDATA | b | i)*>
+	<!ELEMENT ni (#PCDATA)>
 
-	  <!ELEMENT widgets (widget*)>
-
-	  <!ELEMENT widget (overview,usage,properties,children,events,actions,clientprops,sample)>
-
-	  <!ELEMENT overview (ANY)>
-
-	  <!ELEMENT usage (ANY)>
-
-	  <!ELEMENT properties (property*)>
-
-	  <!ELEMENT property (ANY)>
-
-	  <!ELEMENT children (child*)>
-
-	  <!ELEMENT child (childproperty*)>
-
-	  <!ELEMENT childproperty (ANY)>
-
-	  <!ELEMENT events (event*)>
-
-	  <!ELEMENT event (ANY)>
-
-	  <!ELEMENT actions (action*)>
-
-	  <!ELEMENT action (ANY)>
-
-	  <!ELEMENT clientprops (clientprop*)>
-
-	  <!ELEMENT clientprop (ANY)>
-
-	  <!ELEMENT sample (#PCDATA)>
-
-
-
-	  <!ATTLIST widget    
-
-		    name           ID         #REQUIRED
-
-		    type           CDATA      #REQUIRED
-
-		    description    CDATA      #IMPLIED
-
-		    visual         (yes|no)   #IMPLIED
-
-		    formelement    (yes|no)   #IMPLIED
-
-		    container      (yes|no)   #IMPLIED
-
-		    osrcclient     (yes|no)   #IMPLIED
-
-		    >
-
-	  <!ATTLIST property
-
-		    name           CDATA      #REQUIRED
-
-		    type           CDATA      #REQUIRED
-
-		    >
-
-	  <!ATTLIST child
-
-		    type           CDATA      #REQUIRED
-
-		    >
-
-	  <!ATTLIST childproperty
-
-		    name           CDATA      #REQUIRED
-
-		    type           CDATA      #REQUIRED
-
-		    >
-
-	  <!ATTLIST event
-
-		    name           CDATA      #REQUIRED
-
-		    >
-
-	  <!ATTLIST action
-
-		    name           CDATA      #REQUIRED
-
-		    >
-
-	  <!ATTLIST clientprop
-
-		    name           CDATA      #REQUIRED
-
-		    type           CDATA      #REQUIRED
-
-		    >
-
+	<!-- Define attribute lists for widget elements. -->
+	<!ATTLIST widget    
+		name           ID         #REQUIRED
+		type           CDATA      #REQUIRED
+		description    CDATA      #IMPLIED
+		visual         (yes|no)   #IMPLIED
+		formelement    (yes|no)   #IMPLIED
+		container      (yes|no)   #IMPLIED
+		osrcclient     (yes|no)   #IMPLIED
+	>
+	<!ATTLIST property
+		name           CDATA      #REQUIRED
+		type           CDATA      #REQUIRED
+		subtype        CDATA      #IMPLIED
+		enum           CDATA      #IMPLIED
+	>
+	<!ATTLIST child
+		type           CDATA      #REQUIRED
+	>
+	<!ATTLIST childproperty
+		name           CDATA      #REQUIRED
+		type           CDATA      #REQUIRED
+	>
+	<!ATTLIST event
+		name           CDATA      #REQUIRED
+	>
+	<!ATTLIST action
+		name           CDATA      #REQUIRED
+	>
+	<!ATTLIST clientprop
+		name           CDATA      #REQUIRED
+		type           CDATA      #REQUIRED
+	>
 ]>
 
 <widgets>
@@ -160,7 +133,7 @@
 
 		</children>
 
-		<!--<events>
+		<events>
 
 		</events>
 
@@ -170,7 +143,7 @@
 
 		<clientprops>
 
-		</clientprops>-->
+		</clientprops>
 
 		<sample>
 
@@ -250,9 +223,9 @@ vbox1 "widget/vbox"
 
 	    </properties>
 		
-		<!--<children>
+		<children>
 
-		</children>-->
+		</children>
 
 		<events>
 		
@@ -270,13 +243,13 @@ vbox1 "widget/vbox"
 
 		</events>
 
-		<!--<actions>
+		<actions>
 
 		</actions>
 
 		<clientprops>
 
-		</clientprops>-->
+		</clientprops>
 
 		<sample>
 
@@ -346,9 +319,9 @@ vbox1 "widget/vbox"
 
 		</properties>
 
-		<!--<children>
+		<children>
 
-		</children>-->
+		</children>
 
 		<events>
 		
@@ -364,13 +337,13 @@ vbox1 "widget/vbox"
 
 		</events>
 
-		<!--<actions>
+		<actions>
 
 		</actions>
 
 		<clientprops>
 
-		</clientprops>-->
+		</clientprops>
 
 		<sample>
 
@@ -481,9 +454,9 @@ chart "widget/chart"
 
 		</properties>
 
-		<!--<children>
+		<children>
 
-		</children>-->
+		</children>
 
 		<events>
 
@@ -509,9 +482,9 @@ chart "widget/chart"
 
 		</actions>
 
-		<!--<clientprops>
+		<clientprops>
 
-		</clientprops>-->
+		</clientprops>
 
 		<sample>
 
@@ -1591,7 +1564,7 @@ mySoundPlayer "widget/execmethod"
 
 			<property name="next_form_within" type="string" subtype="widget"><ni/>Similar to "next_form", but searches for the next form after this one within a given widget or component.  Transitioning from one component context to another is permitted (you could specify a "widget/page" widget here, and cause focus to transfer to another form in the same application, regardless of level of component nesting; this may or may not be desired behavior).</property>
 
-			<property name="objectsource">Represents the widget object source (transfers data to and from server).</property>
+			<property name="objectsource" type="string">Represents the widget object source (transfers data to and from server).</property>
 			
 			<property name="ReadOnly" type="integer"><ni/>Allow changes.</property>
 
@@ -1754,9 +1727,9 @@ form1 "widget/form"
 
 		</properties>
 
-		<!--<children>
+		<children>
 
-		</children>-->
+		</children>
 
 		<events>
 
@@ -1772,9 +1745,9 @@ form1 "widget/form"
 
 		</events>
 
-		<!--<actions>
+		<actions>
 		
-		</actions>-->
+		</actions>
 
 		<sample>
 
@@ -1905,6 +1878,10 @@ BigFrameset "widget/frameset"
 			<p>An autolayout widget with style set to "hbox".  See "widget/autolayout".</p>
 
 		</overview>
+		
+		<usage>See "widget/autolayout"</usage>
+
+		<properties/>
 
 	</widget>
 	
@@ -1959,7 +1936,7 @@ BigFrameset "widget/frameset"
 			
 		</properties>
 
-		<!--<children>
+		<children>
 
 		</children>
 
@@ -1973,7 +1950,7 @@ BigFrameset "widget/frameset"
 
 		<clientprops>
 
-		</clientprops>-->
+		</clientprops>
 
 		<sample>
 
@@ -2219,9 +2196,9 @@ HTMLArea "widget/html"
 
 		</properties>
 
-		<!--<children>
+		<children>
 
-		</children>-->
+		</children>
 
 		<events>
 
@@ -2247,11 +2224,11 @@ HTMLArea "widget/html"
 
 		</actions>
 		
-		<clientprop>
+		<clientprops>
 		
 			<clientprop name="enabled" type="yes/no or expr">Whether or not the imagebutton should be enabled.  Defaults to 'yes'.  Can be an expression that if uses runclient() will cause the enabled status of the imagebutton to 'follow' the value of that expression while the application is running.</clientprop>
 
-		</clientprop>
+		</clientprops>
 
 		<sample>
 
@@ -2902,9 +2879,9 @@ MyPage "widget/page"
 
 		</properties>
 
-		<!--<children>
+		<children>
 
-		</children>-->
+		</children>
 		
 		<clientprops>
 		
@@ -3168,6 +3145,8 @@ testradio "widget/radiobuttonpanel"
 
 		</usage>
 
+		<properties/>
+
 		<sample>
 
 		<![CDATA[
@@ -3197,6 +3176,8 @@ testradio "widget/radiobuttonpanel"
 			<p>The remote control manager widget is a nonvisual widget and thus cannot contain visual widgets.It is normally located at the top-level of an application, within a "widget/page" object.</p>
 
 		</usage>
+
+		<properties/>
 
 		<sample>
 
@@ -3405,6 +3386,8 @@ $Version=2$
 			<event name="MouseOver">This event occurs when the user first moves the mouse pointer over the widget.  It will not occur again until the user moves the mouse off of the widget and then back over it again.</event>
 
 			<event name="MouseUp">This event occurs when the user releases the mouse button on the widget.</event>
+			
+			<note>The Click, Wheel, MouseDown, and MouseUp events provide several pieces of useful information, including :shiftKey, :ctrlKey, :altKey, and :metaKey, which are 1 if the respective key is held down and 0 otherwise. These events also provide :button, a number representing the button number that the user used to execute the event (which appears to always be 0 for wheel).</note>
 
 		</events>
 		
@@ -3597,7 +3580,7 @@ myTabControl "widget/tab"
 
 			<p>A table widget is used to display data in a tabular format. It consists of a header row with column labels, followed by any number of rows containing data.The header may have a different color or image scheme than the rows, and the rows may or may not be configured to alternate between two colors or background images.</p>
 
-		<span class='__TEXT__'>Table widgets come in three different flavors: static, dynamicpage, and dynamicrow.Static table widgets are built on the server and write their data directly into the container in which they reside, which is usually a scrollpane widget.  Dynamicpage table widgets load their data once they initialize on the client, by activating a query through an ObjectSource nonvisual widget.Dynamicpage table widgets do not support modification, but can be reloaded through an ObjectSource at will.Dynamicrow table widgets, on the other hand, display each row as an individual layer, and thus are modifiable on the client. Dynamicrow table widgets also load their contents through an ObjectSource widget query.As of the time of writing of this document, only <i>static</i> mode and <i>dynamicrow</i> mode were supported.</span>
+		<p>Table widgets come in three different flavors: static, dynamicpage, and dynamicrow.Static table widgets are built on the server and write their data directly into the container in which they reside, which is usually a scrollpane widget.  Dynamicpage table widgets load their data once they initialize on the client, by activating a query through an ObjectSource nonvisual widget.Dynamicpage table widgets do not support modification, but can be reloaded through an ObjectSource at will.Dynamicrow table widgets, on the other hand, display each row as an individual layer, and thus are modifiable on the client. Dynamicrow table widgets also load their contents through an ObjectSource widget query.As of the time of writing of this document, only <i>static</i> mode and <i>dynamicrow</i> mode were supported.</p>
 
 			<p>Table widgets allow the selection (keyboard, mouse, and data focus) of individual rows.</p>
 
@@ -3819,12 +3802,11 @@ tblFileList "widget/table"
 
 		</usage>
 
-		<!--
 		<properties>
 
-		  <property name="" type=""></property>
+			<property name="" type=""/>
 
-		</properties>-->
+		</properties>
 
 		<children>
 
@@ -3836,7 +3818,7 @@ tblFileList "widget/table"
 
 		</children>
 
-		<!--<events>
+		<events>
 
 		</events>
 
@@ -3846,7 +3828,7 @@ tblFileList "widget/table"
 
 		<clientprops>
 
-		</clientprops>-->
+		</clientprops>
 
 		<sample>
 
@@ -3932,9 +3914,9 @@ objcanvas_test "widget/template"
 
 		</properties>
 
-		<!--<children>
+		<children>
 
-		</children>-->
+		</children>
 
 		<events>
 			
@@ -3976,9 +3958,9 @@ objcanvas_test "widget/template"
 		
 		</actions>
 
-		<!--<clientprops>
+		<clientprops>
 
-		</clientprops>-->
+		</clientprops>
 
 		<sample>
 
@@ -4401,6 +4383,10 @@ counter "widget/variable"
 			<p>An autolayout widget with style set to "vbox".  See "widget/autolayout".</p>
 
 		</overview>
+		
+		<usage>See "widget/autolayout"</usage>
+
+		<properties/>
 
 	</widget>
 

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -246,13 +246,13 @@ vbox1 "widget/vbox"
 
 			</ul>
 
-			<p>It should be noted that all of the data for the calendar must fit into the objectsource, or else the calendar will not display all of the available data.  In this manner the calendar's display must be controlled via the objectsource's data.</p>
+			<p>It should be noted that all the data for the calendar must fit into the objectsource, or else the calendar will not display all the available data.  In this manner the calendar's display must be controlled via the objectsource's data.</p>
 
 		</overview>
 
 		<usage>
 
-			<p>The calendar widget can be placed inside of any visual container, but because its height can change, it is often placed inside of a scrollpane widget.  This widget may not contain other visual widgets.</p>
+			<p>The calendar widget can be placed inside any visual container, but because its height can change, it is often placed inside a scrollpane widget.  This widget may not contain other visual widgets.</p>
 
 		</usage>
 
@@ -313,7 +313,7 @@ vbox1 "widget/vbox"
 
 		<usage>
 
-			<p>The chart widget can be placed inside of any visual container, and will attach itself to any objectsource widget that contains it (whether directly or indirectly).  Charts may not contain visual widgets.</p>
+			<p>The chart widget can be placed inside any visual container, and will attach itself to any objectsource widget that contains it (whether directly or indirectly).  Charts may not contain visual widgets.</p>
 
 		</usage>
 
@@ -321,11 +321,11 @@ vbox1 "widget/vbox"
 
 			<property name="chart_type" type="string">Currently supported types are "bar", "line", "scatter", and "pie".  Defaults to "bar".  Chart.js supports much more than this, so new types could be added with relative ease.</property>
 
-			<property name="legend_position" type="string">The position of the legend on the chart.  May be "top", "botton", "left", or "right".</property>
+			<property name="legend_position" type="string">The position of the legend on the chart.  May be "top", "bottom", "left", or "right".</property>
 
 			<property name="objectsource" type="string">The name of the ObjectSource widget which will supply data for the chart.  We recommend that you do not specify this directly but instead embed the chart widget within a parent ObjectSource, directly or indirectly.  If not specified, the chart will look for an ObjectSource in its parents.</property>
 
-			<property name="start_at_zero" type="boolean">Set to false if you want the y axis to start at the lowest data value.  Default is true.</property>
+			<property name="start_at_zero" type="boolean">Set to false if you want the y-axis to start at the lowest data value.  Default is true.</property>
 
 			<property name="title" type="string">The title of the chart.  Default is none.</property>
 
@@ -343,13 +343,13 @@ vbox1 "widget/vbox"
 
 				<childproperty name="color" type="string">A color, RGB or named, for the chart element (ex: line) which represents this series.</childproperty>
 
-				<childproperty name="fill" type="boolean">Set to false to remove the color fill beneath a line chart.  Default is true.</childproperty>
+				<childproperty name="fill" type="boolean">Specify false to remove the color fill behind a line chart.  Default is true.</childproperty>
 
 				<childproperty name="label" type="string">A label for the data series.</childproperty>
 
-				<childproperty name="x_column" type="string">Which column in the data should be used for the x axis? By default, the chart will pick one for you.</childproperty>
+				<childproperty name="x_column" type="string">Which column in the data should be used for the x-axis? By default, the chart will pick one for you.</childproperty>
 
-				<childproperty name="y_column" type="string">Which column in the data should be used for the y axis? By default, the chart will pick one for you.</childproperty>
+				<childproperty name="y_column" type="string">Which column in the data should be used for the y-axis? By default, the chart will pick one for you.</childproperty>
 
 			</child>
 
@@ -408,7 +408,7 @@ chart "widget/chart"
 
 		<usage>
 
-			<p>The checkbox widget can be placed inside of any visual container, and will attach itself to any form widget that contains it (whether directly or indirectly).  Checkboxes may not contain visual widgets.</p>
+			<p>The checkbox widget can be placed inside any visual container, and will attach itself to any form widget that contains it (whether directly or indirectly).  Checkboxes may not contain visual widgets.</p>
 
 		</usage>
 
@@ -521,7 +521,7 @@ checkbox_test "widget/page"
 
 			<property name="border_style" type="string">Determines the look of the outline.</property>
 
-			<property name="closetype" type="string">Decides wither the screen closes widthwise (1) or heightwise (2).</property>
+			<property name="closetype" type="string">Specifies whether the screen closes widthwise (1) or heightwise (2).</property>
 
 			<property name="gshade" type="string">Acts as a boolean to declare if the window is shaded or not (all but title bar minimized).</property>
 
@@ -646,7 +646,7 @@ MyWindow "widget/childwindow"
 
 		<usage>
 
-			<p>The clock widget can be used inside of any container capable of having visual subwidgets.  It may contain no widgets other than any applicable connectors.</p>
+			<p>The clock widget can be used inside any container capable of having visual subwidgets.  It may contain no widgets other than any applicable connectors.</p>
 
 		</usage>
 
@@ -727,7 +727,7 @@ MyWindow "widget/childwindow"
 
 			<property name="auto_destroy" type="yes/no">If enabled (dynamic single-instantiation components only), when a component is instantiated a second time, the original component is automatically destroyed so there is at most one instance at a time in existence.  Defaults to 'yes'.</property>
 
-			<property name="form" type="integer">Can specify another form to be a child of (if different than the implied form in which this control is nested).</property>
+			<property name="form" type="integer">Can specify another form to be a child of (if different from the implied form in which this control is nested).</property>
 
 			<property name="height" type="integer">Height, in pixels, of the component.  If unset, this defaults to the height of the component's containing widget.</property>
 
@@ -953,9 +953,9 @@ my_button "widget/component-decl"
 
 			<property name="event" type="string" subtype="widgetevent">The name of the event that this connector will act on.</property>
 
-			<property name="source" type="string" subtype="widget">The name of the widget generating the event (defaults to the widget the connector is placed inside of).</property>
+			<property name="source" type="string" subtype="widget">The name of the widget generating the event (default: the connector's parent widget).</property>
 
-			<property name="target" type="string" subtype="widget">The name of another widget on the page whose action will be called by this connector (if unspecified, defaults to the widget the connector is placed inside of).</property>
+			<property name="target" type="string" subtype="widget">The name of another widget on the page whose action will be called by this connector (default: the connector's parent widget).</property>
 
 		</properties>
 
@@ -1028,7 +1028,7 @@ cn1 "widget/connector"
 
 			<property name="height" type="integer">Height, in pixels, of the bar.</property>
 
-			<property name="initialdate" type="string">Used to set the initialdate by a string.</property>
+			<property name="initialdate" type="string">Sets the initial date from the specified string.</property>
 
 			<property name="search_by_range" type="yes/no">Default "yes".  Specifies that when the datetime widget is in a form that is in search (QBF) mode, the datetime should display both a "start" and an "end" calendar so the user can search for records/objects matching a range of dates.</property>
 
@@ -1464,7 +1464,7 @@ mySoundPlayer "widget/execmethod"
 
 		<overview>
 
-			<p>The form widget is used as a high-level container for form elements.  Essentially, a form widget represents a single record of data, or the attributes of a single object in the objectsystem (or of a single query result set object).  Form widgets must be used in conjunction with an ObjectSource widget, which does the actual transferring of data to and from the server.</p>
+			<p>The form widget is used as a high-level container for form elements.  Essentially, a form widget represents a single record of data, or the attributes of a single object in the object system (or of a single query result set object).  Form widgets must be used in conjunction with an ObjectSource widget, which does the actual transferring of data to and from the server.</p>
 
 			<p>Forms have five different "modes"of operation, each of which can be specifically allowed or disallowed for the form.</p>
 
@@ -1478,7 +1478,7 @@ mySoundPlayer "widget/execmethod"
 
 			<p>Occasionally, the user may perform an operation which inherently disregards that the form may contain unsaved data.  When this occurs and there is newly created or modified data in the form, the application must ask the user whether the data in the form should be saved or discarded, or whether to simply not even perform the operation in question.  Since DHTML does not inherently have a "three-way confirm" message box (with save, discard, and cancel buttons), Centrallix allows a form to specify a "three-way confirm" window.  This should be a hidden (visible=no) "widget/htmlwindow" object which may contain any content, but should at least contain three buttons named "_3bConfirmSave", "_3bConfirmDiscard", and "_3bConfirmCancel" directly in the htmlwindow.  During a confirm operation, this window will become "application-modal"; that is, no other widgets in the application may be accessed by the user until one of the three buttons is pushed.</p>
 
-			<p>Several settings on the form widget control what state, or "mode", the form can be in: allow_query, allow_new, allow_modify, allow_view, and allow_nodata.  These can beused to constrain a form to perform a specific task, such as only searching, or only creating new records.  For example, a form with only allow_search enabled will always return to the search (QBF) mode and will never display the searched-for data that is returned in the objectsource.</p>
+			<p>Several settings on the form widget control what state, or "mode", the form can be in: allow_query, allow_new, allow_modify, allow_view, and allow_nodata.  These can be used to constrain a form to perform a specific task, such as only searching, or only creating new records.  For example, a form with only allow_search enabled will always return to the search (QBF) mode and will never display the searched-for data that is returned in the objectsource.</p>
 
 		</overview>
 
@@ -1508,7 +1508,7 @@ mySoundPlayer "widget/execmethod"
 
 			<property name="confirm_delete" type="yes/no"><ni />Whether to pop up an OK/Cancel message box asking the user whether he/she is sure the record should be deleted.</property>
 
-			<property name="comfirm_discard" type="yes/no">Set to true when the discard button of the 3 buttom confirm window (3bconfirmwindow) is pressed.</property>
+			<property name="comfirm_discard" type="yes/no">Set to true when the discard button of the 3 button confirm window (3bconfirmwindow) is pressed.</property>
 
 			<property name="enter_mode" type="string"><ni />Can be "save" (default), "nextfield", or "lastsave".  Controls what to do when the user presses ENTER while in a form element in this form.  "save" means to save the record immediately.  "nextfield" means to move to the next form field, as if TAB were pressed instead.  "lastsave" means to move to the next form field, but once ENTER is pressed on the very last field, to then save the record.  Most people prefer "save" for this, since that is consistent with how normal applications work, but people in finance or accounting work often prefer "lastsave" since it allows them to perform high-speed data entry using a numeric keypad.</property>
 
@@ -1850,7 +1850,7 @@ BigFrameset "widget/frameset"
 
 		<usage>
 
-			<p>The hints widget can be placed inside of any visual component.  Hints do not contain visual widgets.</p>
+			<p>The hints widget can be placed inside any visual component.  Hints do not contain visual widgets.</p>
 
 		</usage>
 
@@ -1957,7 +1957,7 @@ f_trx_mod "widget/checkbox"
 
 			<property name="prologue" type="string">HTML source to be inserted at the beginning of the HTML document.</property>
 
-			<property name="source" type="string">The objectsystem path or URL containing the document to be loaded into the HTML as local server.</property>
+			<property name="source" type="string">The object system path or URL containing the document to be loaded into the HTML as local server.</property>
 
 			<property name="width" type="integer">Width, in pixels, of the HTML area as a whole.</property>
 
@@ -1983,7 +1983,7 @@ f_trx_mod "widget/checkbox"
 
 		<actions>
 
-			<action name="LoadPage">Loadpage action takes two parameters.  "Source" contains the URL for the new page to be loaded into the HTML area.The optional parameter "Transition" indicates the type of fade to be used between one page and the next.Currently supported values are "pixelate", "rlwipe", and "lrwipe".</action>
+			<action name="LoadPage">The LoadPage action takes two parameters.  "Source" contains the URL for the new page to be loaded into the HTML area.The optional parameter "Transition" indicates the type of fade to be used between one page and the next.Currently supported values are "pixelate", "rlwipe", and "lrwipe".</action>
 
 		</actions>
 
@@ -2032,7 +2032,7 @@ HTMLArea "widget/html"
 
 		<properties>
 
-			<property name="aspect" type="sting">Determines wither the image can be stretched or must stay its original aspect ration.</property>
+			<property name="aspect" type="sting">Specifies whether the image can be stretched or must stay its original aspect ratio.</property>
 
 			<property name="fieldname" type="string">If using a form for the image path, the name of the column in the datasource you want to reference.</property>
 
@@ -2056,9 +2056,9 @@ HTMLArea "widget/html"
 
 			<clientprop name="source" type="string">An OSML pathname for the location of the image (such as a png or jpg file).</clientprop>
 
-			<clientprop name="xoffset" type="integer">Distance it is along the x axis from its parent widget.</clientprop>
+			<clientprop name="xoffset" type="integer">Distance it is along the x-axis from its parent widget.</clientprop>
 
-			<clientprop name="yoffset" type="integer">Distance it is along the y axis from its parent widget.</clientprop>
+			<clientprop name="yoffset" type="integer">Distance it is along the y-axis from its parent widget.</clientprop>
 
 		</clientprops>
 
@@ -2095,7 +2095,7 @@ HTMLArea "widget/html"
 
 		<overview>
 
-			<p>The ImageButton widget provides a clickable button that is comprised of a set of two or three images.The first image is shown normally when the button is idle, the second when the button is pointed-to, and the third image is shown when the button is actually clicked.  This provides a "tri-state" appearance much like that provided by buttons in modern user interfaces, although the button can be two-state, with just an "unclicked" and "clicked" version of the image.</p>
+			<p>The ImageButton widget provides a clickable button composed of two or three images.  The first image is shown normally when the button is idle, the second when the button is pointed-to, and the third image is shown when the button is actually clicked.  This provides a "tri-state" appearance much like that provided by buttons in modern user interfaces, although the button can be two-state, with just an "unclicked" and "clicked" version of the image.</p>
 
 			<p>The images are automatically swapped out when the appropriate mouse events occur on the button.</p>
 
@@ -2210,7 +2210,7 @@ MyButton "widget/imagebutton"
 
 		<usage>
 
-			<p>The label widget can be placed inside of any visual container, and will attach itself to any form widget that contains it (whether directly or indirectly).  Labels may not contain visual widgets.</p>
+			<p>The label widget can be placed inside any visual container.  It will attach itself to any form widget that contains it (whether directly or indirectly).  Labels may not contain visual widgets.</p>
 
 		</usage>
 
@@ -2315,7 +2315,7 @@ f_trx_mod_l "widget/label" { width=86; text="User Edit?"; align=right; font_size
 
 		<usage>
 
-			<p>Menus can be placed inside of any visual container.  However, be aware that the menu will be clipped by its container, so placing them at the top-level can be of an advantage.  Menu widgets contain menuitem widgets, which are also described in this section.</p>
+			<p>Menus can be placed inside any visual container.  However, be aware that the menu will be clipped by its container, so menus are usually placed inside top level widgets (e.g. page).  Menu widgets contain menuitem widgets, which are also described here.</p>
 
 		</usage>
 
@@ -2385,7 +2385,7 @@ f_trx_mod_l "widget/label" { width=86; text="User Edit?"; align=right; font_size
 
 		<events>
 
-			<event name="DataChange">This event occurs when the an item in the menu which is not a submenu is changed.</event>
+			<event name="DataChange">This event occurs when an item in the menu which is not a submenu is changed.</event>
 
 			<event name="GetFocus">This event occurs when the menu which previously was not clicked is clicked.</event>
 
@@ -2454,7 +2454,7 @@ myMenu "widget/menu"
 
 			<p>Both form and dynamic table widgets interact with the objectsource nonvisual widget to acquire data, update data, create data, and delete data.  In fact, it is possible for more than one form and/or table to be connected with a given objectsource, to perform a variety of functions.</p>
 
-			<p>Objectsources offer synchronization with other objectsources via the Sync and DoubleSync actions (see below) or rule-based connnectivity (see widget/rule).  These actions allow the application to contain multiple objectsources with primary key / foreign key relationships, and to have those objectsources automatically stay in synchronization with each other based on those relationships.</p>
+			<p>Object sources offer synchronization with other object sources via the Sync and DoubleSync actions (see below) or rule-based connectivity (see widget/rule).  These actions allow the application to contain multiple object sources with primary key / foreign key relationships, and to have those object sources automatically stay in synchronization with each other based on those relationships.</p>
 
 			<p>An objectsource may also be used to run a query which does not return any rows, such as an insert, update, or delete query.  Under normal data maintenance conditions such queries are not needed as the objectsource handles those operations internally, however.</p>
 
@@ -2551,7 +2551,7 @@ myMenu "widget/menu"
 
 		<actions>
 
-			<action name="BeginCreateObject">Creates a base of an object and notifies all childeren that a child is creating an object.</action>
+			<action name="BeginCreateObject">Creates a base of an object and notifies all children that a child is creating an object.</action>
 
 			<action name="CancelCreateObject">If it is called while an object is being created it stops the creation and cleans up the mess.</action>
 
@@ -2567,7 +2567,7 @@ myMenu "widget/menu"
 
 			<action name="DeleteClients">Stops relations with all clients and forces them to resync.</action>
 
-			<action name="DoubleSync">DEPRECATED: Performs a double synchronization with two other objectsources, known as the Parent and the Child, in two steps.  The first step is like Sync (see below), with a ParentOSRC and ParentKey1-ParentKey9] / ParentSelfKey1-ParentSelfKey9.  Next, a Sync is performed between the current objectsource and the ChildOSRC in the same way the first step performed a sync between the ParentOSRC and the current objectsource, respectively, using SelfChildKey1-SelfChildKey9 / ChildKey1-ChildKey9.</action>
+			<action name="DoubleSync">DEPRECATED: Performs a double synchronization with two other object sources, known as the Parent and the Child, in two steps.  The first step is like Sync (see below), with a ParentOSRC and ParentKey1-ParentKey9] / ParentSelfKey1-ParentSelfKey9.  Next, a Sync is performed between the current objectsource and the ChildOSRC in the same way the first step performed a sync between the ParentOSRC and the current objectsource, respectively, using SelfChildKey1-SelfChildKey9 / ChildKey1-ChildKey9.</action>
 
 			<action name="FindObject">Searches for a certain object in the replica (retrieved records), and makes it the current object.  Parameters: To search by record number, set ID equal to the integer (1 = first record).  To search by object name (primary key), set Name equal to a string containing the primary key (note that concatenated keys use | as a separator).  To search by other abitrary field values, set those values in the parameters to this action.</action>
 
@@ -2688,7 +2688,7 @@ osrc1 "widget/osrc"
 
 			<property name="kbdfocus2" type="string">A color, RGB or named, for the bottom and right edges of rectangles drawn to indicate keyboard focus (default is dark grey).</property>
 
-			<property name="linkcolor" type="string">Color for hyper links.</property>
+			<property name="linkcolor" type="string">Color for hyperlinks.</property>
 
 			<property name="loadstatus" type="string">True if page is loaded, false otherwise.</property>
 
@@ -2835,7 +2835,7 @@ MyPage "widget/page"
 
 			<action name="Resize">Changes the width and height of the pane to the given (Width,Height).</action>
 
-			<action name="SetBackground">Sets the backgound image or color of the pane, using the attribute Color or Image.</action>
+			<action name="SetBackground">Sets the background image or color of the pane, using the attribute Color or Image.</action>
 
 		</actions>
 
@@ -2845,7 +2845,7 @@ MyPage "widget/page"
 
 $Version=2$
 
-mypane "widget/pane"
+my_pane "widget/pane"
 
 	{
 
@@ -2886,7 +2886,7 @@ mypane "widget/pane"
 
 			<property name="deploy_to_client" type="yes/no">Parameter widgets are treated as other widgets and normally would appear as widgets in the namespace on the client, with the parameter values being available in runclient() expressions on the client.  For efficiency reasons, however, parameters to static components, other than parameters of type "object", are not deployed to the client.  To override this behavior, set this option to "yes".</property>
 
-			<property name="find_container" type="string">If this is a parameter to a component, and the parameter has type "object", this can be set to a type of widget that should be searched for in the containing application or component once the component is instantiated.  Note that the object being searched for must be a container of the component instance, either directly or indirectly.  This option is frequently used to link in with a form or objectsource in the contianing application or component, without that form or objectsource having to be explicitly passed to the component.</property>
+			<property name="find_container" type="string">If this is a parameter to a component, and the parameter has type "object", this can be set to a type of widget that should be searched for in the containing application or component once the component is instantiated.  Note that the object being searched for must be a container of the component instance, either directly or indirectly.  This option is frequently used to link in with a form or objectsource in the containing application or component, without that form or objectsource having to be explicitly passed to the component.</property>
 
 			<property name="param_name" type="string">Gives the name of the parameter being passed, thus allowing the parameter widget name (which must be unique within the application or component) to be different from the parameter name as referenced within expressions, SQL, or connectors.</property>
 
@@ -2975,7 +2975,7 @@ my_cmp "widget/component-decl"
 
 		<usage>
 
-			<p>The radio button panel can be placed inside of any visual container, and will automatically attach itself to a form widget if it is inside of one (directly or indirectly).  The "widget/radiobuttonpanel" is the main widget, and can contain any number of "widget/radiobutton" widgets which specify the choices which will be present on the panel.  No other visual widgets can be contained within a radio button panel.</p>
+			<p>The radio button panel can be placed inside any visual container, and will automatically attach itself to a form widget if it is inside of one (directly or indirectly).  The "widget/radiobuttonpanel" is the main widget, and can contain any number of "widget/radiobutton" widgets which specify the choices which will be present on the panel.  No other visual widgets can be contained within a radio button panel.</p>
 
 			<p>Note: form widget interaction was not yet implemented as of the time of writing of this document.</p>
 
@@ -3083,7 +3083,7 @@ testradio "widget/radiobuttonpanel"
 
 			<p>The remote control manager nonvisual widget allows for one application (or instance of an application) to activate Actions in another running application, even if those applications are on two separate client computer systems.  This is done by passing the event/action information through a remote control channel on the server.</p>
 
-			<p>Two remote control widgets are required: a master and slave.  This widget is the master widget, which sends remote control events via the Centrallix server.  When a this widget sends an event through the channel, the slave widget (remotectl) is automatically activated and can then trigger the appropriate action on another widget on the remote application's page.</p>
+			<p>Two remote control widgets are required: a master and slave.  This widget is the master widget, which sends remote control events via the Centrallix server.  When this widget sends an event through the channel, the slave widget (remotectl) is automatically activated and can then trigger the appropriate action on another widget on the remote application's page.</p>
 
 			<p>In order for the remote control event to be passed through Centrallix, the master and slave widgets must both be using the same channel id and be logged in with the same username.They need not be a part of the same session on the server.</p>
 
@@ -3565,7 +3565,7 @@ myTabControl "widget/tab"
 
 			<property name="outer_border" type="integer">width of the outer spacing around the outside of the table, in pixels.  Default0.</property>
 
-			<property name="overlap_scrollbar" type="integer">Acts as a boolean to allow the scroll bar to overlab with the table (allow is "1").</property>
+			<property name="overlap_scrollbar" type="integer">Acts as a boolean to allow the scroll bar to overlap with the table (allow is "1").</property>
 
 			<property name="reverse_order" type="integer">Acts as a boolean to reverse to order of the table elements (reverses if set to "1").</property>
 
@@ -3649,7 +3649,7 @@ myTabControl "widget/tab"
 
 			<event name="DblClick">The DblClick event fires when the user double-clicks the mouse on a row.  Passes three values, 'Caller' which is the table's name, 'recnum' which is the sequential number of the record in the table, and 'data' which is an array of the data in the selected record.</event>
 
-			<event name="RightClick">The Click event fires when a user right clicks on a mouse or mouse pad.</event>
+			<event name="RightClick">The RightClick event occurs when a user clicks on the widget with the relevant button on their mouse or mouse pad.</event>
 
 		</events>
 
@@ -4031,7 +4031,7 @@ $Version=2$
 
 //
 
-mytimerOne "widget/timer"
+my_timer1 "widget/timer"
 
 	{
 
@@ -4045,7 +4045,7 @@ mytimerOne "widget/timer"
 
 		{ 
 
-		event="Expire"; target="mytimerTwo";action="SetTimer";
+		event="Expire"; target="my_timer2";action="SetTimer";
 
 		Time="500"; AutoReset="0";
 
@@ -4053,7 +4053,7 @@ mytimerOne "widget/timer"
 
 	}
 
-mytimerTwo "widget/timer"
+my_timer2 "widget/timer"
 
 	{
 
@@ -4067,7 +4067,7 @@ mytimerTwo "widget/timer"
 
 		{ 
 
-		event="Expire"; target="mytimerOne";action="SetTimer";
+		event="Expire"; target="my_timer1";action="SetTimer";
 
 		Time="500"; AutoReset="0";
 
@@ -4094,7 +4094,7 @@ mytimerTwo "widget/timer"
 
 		<usage>
 
-			<p>Treeviews can be placed inside of any visual container, but are usually placed inside of a scrollpane, since scrollpanes can expand to allow the user to view data that would not normally fit inside the desired container.  Treeviews can contain only nonvisual widgets such as connectors.</p>
+			<p>Treeviews can be placed inside any visual container, but are usually placed inside a scrollpane, since scrollpanes can expand to allow the user to view data that would not normally fit inside the desired container.  Treeviews can contain only nonvisual widgets such as connectors.</p>
 
 		</usage>
 
@@ -4114,7 +4114,7 @@ mytimerTwo "widget/timer"
 
 			<property name="show_root" type="yes/no">Whether to display the root of the tree.  If "no", then the root is auto-expanded and only its children are visible.</property>
 
-			<property name="show_root_branch" type="yes/no">Whether to display the connection lines between the root and the root's immediate children.  If "no", the root's children are flush against the lefthand side of the treeview, otherwise the connecting lines show up.</property>
+			<property name="show_root_branch" type="yes/no">Whether to display the connection lines between the root and the root's immediate children.  If "no", the root's children are flush against the left-hand side of the treeview, otherwise the connecting lines show up.</property>
 
 			<property name="source" type="string" subtype="OSMLobject">The ObjectSystem path of the root of the treeview.</property>
 
@@ -4170,7 +4170,7 @@ $Version=2$
 
 // Example of a pane containing a scrollpane containing a treeview.
 
-mypane "widget/pane"
+my_pane "widget/pane"
 
 	{
 
@@ -4180,13 +4180,13 @@ mypane "widget/pane"
 
 	bgcolor = "#c0c0c0";
 
-	myscroll "widget/scrollpane"
+	my_scrollpane "widget/scrollpane"
 
 		{
 
 		x=0; y=0; width=198; height=198;
 
-		mytreeview "widget/treeview"
+		my_treeview "widget/treeview"
 
 			{
 
@@ -4217,7 +4217,7 @@ mypane "widget/pane"
 
 		<usage>
 
-			<p>This nonvisual widget is used at the top-level (within a "widget/page").  Currently it has no events, and so shouldn't contain any visual or nonvisual widgets.</p>
+			<p>This nonvisual widget is used at the top-level (within a "widget/page").  It should not contain any visual or nonvisual child widgets.</p>
 
 		</usage>
 

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -1360,7 +1360,7 @@ myDropDown2 "widget/dropdown"
 
 			<event name="DataChange">This event occurs when the user has modified the data value of the widget (clicked or unclicked it).</event>
 
-			<event name="DataModify">This event occurs when the data is changed (occurs when key press or button changes things).  It provides four parameters. "NewValue" represents the now current value after the modification. "OldValue" representing the previous value.  "FromKeyboard" is 1 if the event is caused by the user typing into the editbox with their keyboard.  "FromOSRC" is 1 if the event is caused by an OSRC modifying the edit box data.</event>
+			<event name="DataModify">This event occurs when the data is changed (occurs when key press or button changes things).  It provides four parameters. "Value" represents the now current value after the modification. "OldValue" representing the previous value.  "FromKeyboard" is 1 if the event is caused by the user typing into the editbox with their keyboard.  "FromOSRC" is 1 if the event is caused by an OSRC modifying the edit box data.</event>
 
 			<event name="EscapePressed">This event occurs when the user presses the escape key.</event>
 

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -1159,7 +1159,7 @@ cn1 "widget/connector"
 
 			<property name="mode" type="string">If this is set to objectsource then the dropdown acts an objectsource client.</property>
 
-			<property name="num_disp" type="integer">Number of widgets displayed at once in the dropdown box.</property>
+			<property name="numdisplay" type="integer">Number of widgets displayed at once in the dropdown box.</property>
 
 			<property name="objectsource" type="string">Represents the widget object source (transfers data to and from server).</property>
 
@@ -1219,7 +1219,7 @@ cn1 "widget/connector"
 
 			<action name="SetGroup">This causes the dropdown to display a different Group of items (use the "Group" parameter).  It can also restrict what items are displayed based on a minimum or maximum value (use "Min" and "Max" parameters).</action>
 
-			<action name="SetItems">This specifies a SQL (use "SQL" parameter) query to use when reloading the contents of the dropdown.  The query should produce between two and five columns the order: label, value, selected (1 for the default selected item, 0 for all others), grp (group name), hidden (1 to hide the item from the dropdown UI even though it's still valid, 0 to show it).  Use the "RowLimit" parameter to specify a maximum number of options that the query should fetch (defaults to 100).</action>
+			<action name="SetItems">This specifies a SQL (see "SQL" parameter) query to use when reloading the contents of the dropdown.  Use the "RowLimit" parameter to specify a maximum number of options that the query should fetch (defaults to 100).</action>
 
 			<action name="SetValue">Changes the child property "Value".</action>
 
@@ -2688,6 +2688,7 @@ myMenu "widget/menu"
 			<property name="receive_updates" type="yes/no">** This feature currently disabled in Centrallix 0.9.1 ** Default "no".  If set to "yes", the objectsource will ask the server to send it updates on any changes that occur on the server side (i.e., if the changes were made by another objectsource or by another user, they would be automatically refreshed into this objectsource in near real-time).</property>
 
 			<property name="refresh_interval" type="integer">The time between the data refreshing, if set to 0 it does not automatically refresh.</property>
+
 			<property name="replicasize" type="integer">Represents the number of records to store in its replica.  This value should be larger than the maximum number of records that will be displayed at any one time.  At times, Centrallix may increase the number of records cached on the client beyond this number.</property>
 
 			<property name="revealed_only" type="string">Acts as a boolean and delays query until the osrc is visable (if "true").</property>
@@ -2706,7 +2707,7 @@ myMenu "widget/menu"
 
 			<child type="rule with ruletype=osrc_relationship (replaces the deprecated: sync and double sync)">
 
-				<childproperty name="autoquery" type="true/false">When autoquery is set to true, when the master changes, the slave automatially requeries (otherwise have to explicitly call requery or refresh on the slave osrc).  When autoquery is false, it causes relationships to be in enforced, but doesn't cause a re-query when the master's osrc refreshes / requeries.</childproperty>
+				<childproperty name="autoquery" type="true/false">When autoquery is set to true, when the master changes, the slave automatically re-queries its data.  Otherwise, it will not re-query unless an action is explicitly called to do so.  When autoquery is false, it causes relationships to be in enforced, but doesn't cause a re-query when the master's osrc refreshes or re-queries.</childproperty>
 
 				<childproperty name="is_slave" type="yes/no">Defaults to 'yes'.  If it is set to 'no', then this osrc is set up to be a master of the target, otherwise the default is for it to be a slave of the target.</childproperty>
 

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -1495,6 +1495,57 @@ mySoundPlayer "widget/execmethod"
 	</widget>
 
 
+	<widget name="fileupload" type="widget/fileupload" visual="no" formelement="no" container="no" description="A nonvisual widget to manage file uploads to the Centrallix server.">
+
+		<overview>
+
+			<p>The fileupload widget is a nonvisual widget that allows the client to upload files to the server.</p>
+
+		</overview>
+
+		<usage>
+
+			<p>The fileupload widget, since it is nonvisual, can be placed almost anywhere but is typically placed at the top-level (within an object of type "widget/page") to improve clarity.  It has no effect on its container.  This widget does cannot contain any visual widgets.</p>
+
+		</usage>
+
+		<properties>
+
+			<property name="target" type="string">The Centrallix object system path to the directory where uploaded files should be placed. (Causes undefined behavior if unspecified.)</property>
+
+			<property name="multiselect" type="integer">Set to 1 to allow the user to pass multiple files at once instead of only selecting a single file (default: 0).</property>
+
+			<property name="form" type="string">Unused.</property>
+
+			<property name="fieldname" type="string">Unused.</property>
+
+		</properties>
+		
+		<events>
+
+			<event name="DataChange">This event occurs when the uploaded file(s) is changed, either because the user selected new file(s) or because the file upload widget was cleared.  It provides two parameters: "NewValue" is the new file name, or an empty string ("") if the widget was cleared, and "OldValue" is the value before the data was changed.</event>
+
+			<event name="UploadComplete">This event occurs when an upload is successfully completed by the user.  It provides several parameters called "OrigNameX" and "NewNameX" where X is a number greater than 0 that appear to relate to the files names that the user has uploaded.</event>
+
+			<event name="UploadError">This event occurs when there is an error during a file upload.  It provides no parameters.</event>
+
+			<event name="Change">This event is registered, but it looks like it never occurs.</event>
+
+		</events>
+
+		<actions>
+
+			<action name="Clear">This action clears whatever file was selected and uploaded by the user.  This action causes a DataChange event with the NewValue parameter set to an empty string ("").  It takes no parameters.</action>
+
+			<action name="Prompt">This action prompts the user to select a file.  It takes no parameters.</action>
+
+			<action name="Submit">This action submits the selected file to be uploaded, possibly causing an UploadComplete, UploadError, or DataChange event.  It takes no parameters.</action>
+
+		</actions>
+	
+	</widget>
+
+
 	<widget name="form" type="widget/form" visual="no" formelement="no" container="yes" description="A nonvisual container used to group a set of form element widgets into a single record or object">
 
 		<overview>

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -3213,6 +3213,34 @@ my_cmp "widget/component-decl"
 
 		</children>
 
+		<events>
+
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
+
+			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
+
+			<event name="MouseMove">This event occurs when the user moves the mouse pointer while it is over the widget (or content inside the widget).  The event will repeatedly fire each time the pointer moves.</event>
+
+			<event name="MouseOut">This event occurs when the user moves the mouse pointer off of the widget.</event>
+
+			<event name="MouseOver">This event occurs when the user first moves the mouse pointer over the widget.  It will not occur again until the user moves the mouse off of the widget and then back over it again.</event>
+
+			<event name="MouseUp">This event occurs when the user releases the mouse button on the widget.</event>
+
+			<event name="DataChange">This event occurs when a new option is selected in the dropdown widget.  It provides the "Value" parameter, which indicates the new selected option.</event>
+
+			<event name="GetFocus">This event occurs when the parent pane gains the user's focus.</event>
+
+			<event name="LoseFocus">This event occurs when the parent pane looses the user's focus.</event>
+
+		</events>
+
+		<actions>
+
+			<action name="SetValue">Sets the selected option for the radio button panel to the new option specified with the "Value" parameter, or unsets the dropdown if no value is specified.</action>
+
+		</actions>
+
 		<sample>
 
 			<![CDATA[

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -3904,7 +3904,17 @@ myTabControl "widget/tab"
 
 			</child>
 
-			<child type="table-row-detail" />
+			<child type="table-row-detail">
+
+				<childproperty name="width" type="integer">Not documented.</childproperty>
+
+				<childproperty name="height" type="integer">The height of the table row detail. (This will expand the height of the selected row when the widget appears.)</childproperty>
+
+				<childproperty name="display_for" type="integer">Specify 0 to hide the row-detail (useful for creating multiple widgets and picking between them dynamically). Support run_client().</childproperty>
+
+				<childproperty name="show_on_new" type="integer">Specify 1 to make new rows show their table-row-detail when added (deault: 0).</childproperty>
+
+			</child>
 
 		</children>
 

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -3860,11 +3860,27 @@ myTabControl "widget/tab"
 
 			<child type="widget/table-column">
 
-				<childproperty name="align" type="string">The alignment of the column: "left" or "right".</childproperty>
+				<childproperty name="align" type="string">The alignment of the column: "left", "center", or "right".</childproperty>
 
-				<childproperty name="caption_fieldname" type="string">It is a pseudonym for the fieldname.</childproperty>
+				<childproperty name="fieldname" type="string">The field name that this column will use to get data.</childproperty>
 
-				<childproperty name="caption_textcolor" type="string">The color of the caption_fieldname.</childproperty>
+				<childproperty name="value" type="string">Not documented.</childproperty>
+
+				<childproperty name="textcolor" type="string">The color of the text displayed in this column.</childproperty>
+
+				<childproperty name="caption_align" type="string">The alignment of the caption in the column: "left", "center", or "right".</childproperty>
+
+				<childproperty name="caption_fieldname" type="string">The field name that this column will use to get caption data.</childproperty>
+
+				<childproperty name="caption_value" type="string">Not documented.</childproperty>
+
+				<childproperty name="caption_textcolor" type="string">The color of the captions in this column.</childproperty>
+
+				<childproperty name="caption_font_size" type="string">The font size of thecaption text.</childproperty>
+
+				<childproperty name="caption_style" type="string">Not documented.</childproperty>
+
+				<childproperty name="caption_wrap" type="string">Determines if the caption text will wrap around obstacles.</childproperty>
 
 				<childproperty name="group_by" type="string">Acts as a boolean to determine if items are group able.</childproperty>
 
@@ -3874,9 +3890,17 @@ myTabControl "widget/tab"
 
 				<childproperty name="type" type="string">The type of the column: "text", "check", or "image".  "text" is a normal column, and displays the textual value of the data element.  "check" displays a checkmark if the data is non-zero (integers) or for strings if the value is non-empty and not "N" or "No".  "image" displays the image referred to by the pathname contained in the data value.</childproperty>
 
+				<childproperty name="image_maxwidth" type="integer">The max width of the image displayed when type=image.</childproperty>
+
+				<childproperty name="image_maxheight" type="integer">The max height of the image displayed when type=image.</childproperty>
+
+				<childproperty name="style" type="string">Not documented.</childproperty>
+
 				<childproperty name="width" type="integer">width of the column.</childproperty>
 
 				<childproperty name="wrap" type="string">Determines if text can wrap around an obstacle.</childproperty>
+
+				<childproperty name="visible" type="integer">Set this to 0 to hide the column from the table.</childproperty>
 
 			</child>
 

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -839,7 +839,7 @@ formctl "widget/component"
 			<p>A widget/component-decl widget must occur at the top level of a component (.cmp) file.</p>
 
 			<p>Other visual and nonvisual widgets may be placed inside a component-decl, in addition to parameters and declarations of Events and Actions that the component generates and handles.</p>
-			
+
 			<p>To declare a client-side property on the component's external interface, place a "widget/component-decl-cprop" inside the component at the top level.  When the external property is changed, a MODIFY event with the same property name is activated inside the component to update its property so that it will match.</p>
 
 			<p>To declare that a component generates an Event, place a "widget/component-decl-event" inside the component at the top level.  No parameters are needed for that Event.  To cause the component to generate the Event, trigger an Action with the same name on the component-decl from inside, and the event will be activated for the containing application or component.</p>
@@ -865,27 +865,27 @@ formctl "widget/component"
 			<property name="visual" type="string">Indicates if the component is seen (not = -1).</property>
 
 		</properties>
-		
+
 		<children>
-			
+
 			<child type="component-decl-cprop">
 
 				<childproperty name="name" type="string">The name of the client-side property to expose.</childproperty>
 
 			</child>
-			
+
 			<child type="component-decl-event">
 
 				<childproperty name="name" type="string">The name of the event to expose.</childproperty>
 
 			</child>
-			
+
 			<child type="component-decl-action">
 
 				<childproperty name="name" type="string">The name of the action to expose.</childproperty>
 
 			</child>
-			
+
 		</children>
 
 		<events>
@@ -1390,7 +1390,6 @@ myDropDown2 "widget/dropdown"
 
 			<action name="Enable">The Enable action allows an edit box to be written in, and takes no parameters x from being written in, and takes no parameters.</action>
 
-
 			<action name="Disable">The Disable action prevents an edit box from being written in. This action takes no parameters.</action>
 
 			<action name="SetFocus">The SetFocus action selects and gives control to an edit box at the specified "X" and "Y" coordinates (even if its not the target?).</action>
@@ -1440,7 +1439,7 @@ my_editbox "widget/editbox"
 
 		<overview>
 
-			<p>The execmethod widget is a nonvisual widget which is used to call ObjectSystem methods on objects on the server.This widget may become deprecated in the future when more advanced OSML API widgets become available.</p>
+			<p>The execmethod widget is a nonvisual widget which is used to call ObjectSystem methods on objects on the server.  This widget may become deprecated in the future when more advanced OSML API widgets become available.</p>
 
 			<p>These widgets are used via the activation of their "ExecuteMethod" action.</p>
 
@@ -1520,7 +1519,7 @@ mySoundPlayer "widget/execmethod"
 			<property name="fieldname" type="string">Unused.</property>
 
 		</properties>
-		
+
 		<events>
 
 			<event name="DataChange">This event occurs when the uploaded file(s) is changed, either because the user selected new file(s) or because the file upload widget was cleared.  It provides two parameters: "NewValue" is the new file name, or an empty string ("") if the widget was cleared, and "OldValue" is the value before the data was changed.</event>
@@ -1542,7 +1541,7 @@ mySoundPlayer "widget/execmethod"
 			<action name="Submit">This action submits the selected file to be uploaded, possibly causing an UploadComplete, UploadError, or DataChange event.  It takes no parameters.</action>
 
 		</actions>
-	
+
 	</widget>
 
 
@@ -2572,7 +2571,7 @@ myMenu "widget/menu"
 
 	bgcolor="#808080";
 
-	
+
 
 	m1 "widget/menuitem" { label="One"; }
 
@@ -3116,7 +3115,7 @@ my_cmp "widget/component-decl"
 
 	width=200; height=32;
 
-	
+
 
 	field_name "widget/parameter"
 
@@ -3870,7 +3869,7 @@ myTabControl "widget/tab"
 				<childproperty name="wrap" type="string">Determines if text can wrap around an obstacle.</childproperty>
 
 			</child>
-			
+
 			<child type="table-row-detail" />
 
 		</children>

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -211,7 +211,7 @@ vbox1 "widget/vbox"
 
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the widget.  No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
@@ -365,9 +365,9 @@ vbox1 "widget/vbox"
 
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the chart. No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
 
-			<event name="DblClick">This event occurs when the user double-clicks the chart. No parameters are available from this event.</event>
+			<event name="DblClick">This event occurs when the user double-clicks the mouse pointer (equivalent to two Click events occuring on the widget within a required time period) while it is over this widget.</event>
 
 		</events>
 
@@ -438,7 +438,7 @@ chart "widget/chart"
 
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the checkbox.  No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
 
 			<event name="DataChange">This event occurs when the user has modified the data value of the checkbox (clicked or unclicked it).</event>
 
@@ -1076,7 +1076,7 @@ cn1 "widget/connector"
 
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the widget.  No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
 
 			<event name="DataChange">This event occurs when the user has modified the data value of the widget (clicked or unclicked it).</event>
 
@@ -1356,7 +1356,7 @@ myDropDown2 "widget/dropdown"
 
 			<event name="BeforeKeyPress">This event occurs before the key press event is fired and can stop the key press event.</event>
 
-			<event name="Click">This event occurs when the user clicks the widget.  No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
 
 			<event name="DataChange">This event occurs when the user has modified the data value of the widget (clicked or unclicked it).</event>
 
@@ -1775,7 +1775,7 @@ form1 "widget/form"
 
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the formstatus widget. No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
@@ -2152,7 +2152,7 @@ HTMLArea "widget/html"
 
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the checkbox.  No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the checkbox.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the checkbox for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
@@ -2231,7 +2231,7 @@ HTMLArea "widget/html"
 
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the button.  No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the checkbox.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the checkbox for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
@@ -2348,7 +2348,7 @@ MyButton "widget/imagebutton"
 
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the checkbox.  No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
 
 			<event name="DataChange">This event occurs when the user has modified the data value of the checkbox (clicked or unclicked it).</event>
 
@@ -3009,7 +3009,7 @@ MyPage "widget/page"
 
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the checkbox.  No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the checkbox.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the checkbox for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
@@ -3424,6 +3424,8 @@ $Version=2$
 
 		<events>
 
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
+
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
 			<event name="MouseMove">This event occurs when the user moves the mouse pointer while it is over the widget.  The event will repeatedly fire each time the pointer moves.</event>
@@ -3483,7 +3485,7 @@ $Version=2$
 
 			<event name="Scroll">This event occurs any time the user scrolls the scroll pane.  This includes scrolling by clicking the scroll buttons, clicking on the scroll bar, dragging the scroll thumb, turning the scroll wheel, or when the ScrollTo action is used.  This event does not occur when the scroll pane moves because the contained content changed in length, or when the scroll pane is forced to scroll because the available visible area was resized.  This event will never occur if the content within the scroll pane is shorter than the available visible area because then the content cannot be scrolled.  This event provides the :Percent attribute, a number from 0 to 100 (the same as the ScrollTo action above) representing the percentage that the user has now scrolled down the page as of the event occurring.  This event also provides :Change, representing how much the user's scroll location has changed in the same unit as above (although this value will be negative if the user scrolled up).</event>
 
-			<event name="Click">This event occurs when the user moves the mouse pointer while it is over the widget.  The event will repeatedly fire each time the pointer moves.</event>
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
 
 			<event name="Wheel">This event occurs when the user moves the scroll wheel while it is over the widget (or content inside the widget).  The event will repeatedly fire each time the pointer moves.</event>
 
@@ -4039,6 +4041,8 @@ objcanvas_test "widget/template"
 
 			<event name="LoseFocus">This event occurs when the editbox loses keyboard focus (if the user tabs off of it, for instance).</event>
 
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.</event>
+
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
 			<event name="MouseMove">This event occurs when the user moves the mouse pointer while it is over the widget.  The event will repeatedly fire each time the pointer moves.</event>
@@ -4130,7 +4134,7 @@ objcanvas_test "widget/template"
 
 		<events>
 
-			<event name="Click">This event occurs when the user clicks the button.  No parameters are available from this event.</event>
+			<event name="Click">This event occurs when the user clicks the mouse pointer (equivalent to a MouseDown followed immediately by a MouseUp on the same widget) while it is over this widget.  This event also has the "from_action" parameter, which is set to 1 if it was triggered by the click action.</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -1645,9 +1645,7 @@ mySoundPlayer "widget/execmethod"
 
 			</child>
 
-			<child type="formstatus">
-
-			</child>
+			<child type="formstatus"/>
 
 		</children>
 
@@ -2173,7 +2171,7 @@ HTMLArea "widget/html"
 
 		<actions>
 
-			<action name="LoadImage">Displays the image to user.</action>
+			<action name="LoadImage">Displays the new image from the provided "Source" path to user.  Specify 1 or yes for the "LinkApp" parameter to pass the full akey session link on in the url request.</action>
 
 			<action name="Offset">Reloads the image with new offset values.</action>
 
@@ -2252,9 +2250,9 @@ HTMLArea "widget/html"
 
 		<actions>
 
-			<action name="Disable">This action causes the image button to enter its 'disabled' state, displaying the 'disabledimage' if specified.</action>
+			<action name="Disable">This action causes the image button to enter its disabled state, displaying the disabledimage if specified.</action>
 
-			<action name="Enable">This action causes the image button to enter its 'enabled' state, possibly changing its appearance if a 'disabledimage' was explicitly specified.</action>
+			<action name="Enable">This action causes the image button to enter its enabled state, possibly changing its appearance if a disabledimage was explicitly specified.</action>
 
 		</actions>
 
@@ -2371,7 +2369,7 @@ MyButton "widget/imagebutton"
 
 		<actions>
 
-			<action name="SetValue">Sets the value property to the given parameter.</action>
+			<action name="SetValue">This sets the value property to the specified "Value".</action>
 
 		</actions>
 
@@ -2929,9 +2927,9 @@ osrc1 "widget/osrc"
 			<action name="Alert">Sends an alert widget.</action>
 			<action name="Close">Closes the page.</action>
 
-			<action name="Launch">Starts a new app in a new window.</action>
+			<action name="Launch">Loads the app at the specified "Source" in a new window of the specified "Width" and "Height".  Specify 1 or yes for "LinkApp" to link the new app into the same group as the current page for permissions.  Specify any value other than no for the "UseragentMenu", "UseragentResize", or "UseragentScroll" parameters to allow the user to see the menu bar, resize the window, or scroll it (respectively).</action>
 			
-			<action name="LoadPage">Loads the page.</action>
+			<action name="LoadPage">Loads the page at the specified "Source".</action>
 
 			<action name="ReloadPage">Reloads the page in the user's browser.  Note: This event forces a reload, even if the original content could be loaded without one.</action>
 
@@ -3040,7 +3038,7 @@ MyPage "widget/page"
 
 			<action name="Resize">Changes the width and height of the pane to the given (Width,Height).</action>
 
-			<action name="SetBackground">Sets the background image or color of the pane, using the attribute Color or Image.</action>
+			<action name="SetBackground">Sets the background to the specified "Image" path or "Color" of the pane.</action>
 
 		</actions>
 
@@ -3107,7 +3105,7 @@ my_pane "widget/pane"
 
 		<actions>
 
-			<action name="SetValue">This sets the value of the parameter.</action>
+			<action name="SetValue">This sets the value property to the specified "Value".</action>
 
 		</actions>
 
@@ -3479,7 +3477,7 @@ $Version=2$
 
 		<actions>
 
-			<action name="MoveTo">Sets the scroll bar to a specific location determined by the parameter.</action>
+			<action name="MoveTo">Sets the scrollbar to a specific location determined by the "Value" parameter.</action>
 
 		</actions>
 
@@ -3697,7 +3695,7 @@ MyScrollPane "widget/scrollpane"
 
 		<actions>
 
-			<action name="SetTab">Sets the selected tab according to the parameter given (the tab itself or its index).</action>
+			<action name="SetTab">Sets the selected tab to the tab with the index specified by the "TabIndex" parameter, or the tab with the name specified by the "Tab" parameter.  ("Tab" takes priority if both are specified.  Does nothing if neither is specified.)</action>
 
 		</actions>
 
@@ -4100,11 +4098,11 @@ objcanvas_test "widget/template"
 
 		<actions>
 
-			<action name="InsertText">Checks to see if things need to be changed (new is different from old) then calls set value.</action>
+			<action name="InsertText">Checks to see if things need to be changed (new is different from old) then calls SetValue with the provided "Text".  Specify 1 for the "SetFocus" parameter to cause this textarea to become the focus when the text is inserted.</action>
 
-			<action name="SetFocus">Sets the focus on a selected widget.</action>
+			<action name="SetFocus">Sets the focus on a selected widget.  Specify the optional "X" or "Y" parameters to move the focus box that appears on the textarea.</action>
 
-			<action name="SetValue">Sets the content to the text parameter sent.</action>
+			<action name="SetValue">Sets the content to the specified "Value" parameter.  You should be able to specify 0 for the "Trigger" parameter to prevent a DataChange event from being triggered, however, this parameter is ignored and the event is always triggered.</action>
 
 		</actions>
 

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -363,6 +363,14 @@ vbox1 "widget/vbox"
 
 		</children>
 
+		<events>
+
+			<event name="Click">This event occurs when the user clicks the chart. No parameters are available from this event.</event>
+
+			<event name="DblClick">This event occurs when the user double-clicks the chart. No parameters are available from this event.</event>
+
+		</events>
+
 		<sample>
 
 			<![CDATA[
@@ -448,7 +456,7 @@ chart "widget/chart"
 
 		<actions>
 
-			<action name="SetValue">This takes a given value and sets the check box value to it.</action>
+			<action name="SetValue">Sets the checkbox using a given number: "Value". Use Value=1 for checked or Value=0 for unchecked.</action>
 
 		</actions>
 
@@ -587,13 +595,13 @@ checkbox_test "widget/page"
 
 			<action name="Close">Closes the window.  Note that widgets inside the window may choose to veto the Close operation: for example, if there is unsaved data in a form.</action>
 
-			<action name="Open">Opens the window.  If the parameter IsModal is set to 1, then the window becomes modal (only the window's contents are accessible to the user until the window is closed).  If the parameter NoClose is set to 1, then the close button in the upper right corner of the window becomes inactive and the window will only close via the Close, SetVisibility, and ToggleVisibility actions.</action>
+			<action name="Open">Opens the window.  Set the "X" and "Y" parameters to the coordinates of the upper-left corner of the window to open it at that location.  If the parameter "Center" is set to any value other than no (the default), the window is centered on the specified coordinates instead.  Set the "PointAt" parameter with a widget name to make the new window point at that widget.  Set the "PointSide" parameter with a value of top, bottom, left, or right to force the window to point from that side.  Set the "PointOffset" parameter to the distance in pixels that the window should be from the widget it points at.  This action also takes the "IsModal","NoClose", and "Cascade" parameters, described in the SetVisibility action.</action>
 
 			<action name="Point">Makes the window relocate to a side using a triangle (pop over).</action>
 
-			<action name="Popup">Opens a window like a pop-up.</action>
+			<action name="Popup">Opens a window like a pop-up at the specified "X" and "Y" with the specified "Width" and "Height" (in pixels).  Or, set the "PopTo" parameter with a widget name to copy those properties from it.  In either case, the "OffsetX" and "OffsetY" parameters move the popup right and down respectively.  Finally, specify the "ExtendTo" parameter with a widget name to ensure that the popup extends to that parameter.</action>
 
-			<action name="SetVisibility">One parameter, "is_visible", which is set to 0 or 1 to hide or show the window, respectively.</action>
+			<action name="SetVisibility">Sets data about how the window displays.  Set the "IsVisible" parameter to 0 (hide) or 1 (show).  Set the "IsModal" parameter to 1 to make the window a modal (only the window's contents are accessible to the user until it is closed). Set the "NoClose" parameter to 1 to make the close button in the upper right corner of the window inactive (the window can only be closed via the Close, SetVisibility, and ToggleVisibility actions).  Set the "Cascade" parameter to 1 to cause multiple appearing windows to autopossition themselves in a cascading pattern.</action>
 
 			<action name="Shade">Turns the gshade property(see above) on.</action>
 
@@ -831,10 +839,12 @@ formctl "widget/component"
 			<p>A widget/component-decl widget must occur at the top level of a component (.cmp) file.</p>
 
 			<p>Other visual and nonvisual widgets may be placed inside a component-decl, in addition to parameters and declarations of Events and Actions that the component generates and handles.</p>
+			
+			<p>To declare a client-side property on the component's external interface, place a "widget/component-decl-cprop" inside the component at the top level.  When the external property is changed, a MODIFY event with the same property name is activated inside the component to update its property so that it will match.</p>
 
 			<p>To declare that a component generates an Event, place a "widget/component-decl-event" inside the component at the top level.  No parameters are needed for that Event.  To cause the component to generate the Event, trigger an Action with the same name on the component-decl from inside, and the event will be activated for the containing application or component.</p>
 
-			<p>Similarly, to declare that a component can receive an Action, place a "widget/component-decl-action" inside the component at the top level.  Again, no parameters are needed.  The containing application or component can then trigger the Action, which will cause an event to occur inside the component.  The event occurs on the component-decl widget (top level of the component), and can be caught with a connector widget.</p>
+			<p>To declare that a component can receive an Action, place a "widget/component-decl-action" inside the component at the top level.  Again, no parameters are needed.  The containing application or component can then trigger the Action, which will cause an event to occur inside the component.  The event occurs on the component-decl widget (top level of the component), and can be caught with a connector widget.</p>
 
 			<p>Components can take parameters just like applications can.  See the "widget/parameter" widget for details on how to declare parameters on applications and components.</p>
 
@@ -855,6 +865,28 @@ formctl "widget/component"
 			<property name="visual" type="string">Indicates if the component is seen (not = -1).</property>
 
 		</properties>
+		
+		<children>
+			
+			<child type="component-decl-cprop">
+
+				<childproperty name="name" type="string">The name of the client-side property to expose.</childproperty>
+
+			</child>
+			
+			<child type="component-decl-event">
+
+				<childproperty name="name" type="string">The name of the event to expose.</childproperty>
+
+			</child>
+			
+			<child type="component-decl-action">
+
+				<childproperty name="name" type="string">The name of the action to expose.</childproperty>
+
+			</child>
+			
+		</children>
 
 		<events>
 
@@ -1066,7 +1098,7 @@ cn1 "widget/connector"
 
 		<actions>
 
-			<action name="SetValue">Generates an internal data object using the data specified or the current time.</action>
+			<action name="SetValue">Set the time of the clock to a new time, specified using "Value".</action>
 
 		</actions>
 
@@ -1185,11 +1217,11 @@ cn1 "widget/connector"
 
 			<action name="ClearItems">Deletes all the widgets in the dropdown menu.</action>
 
-			<action name="SetGroup">This causes the dropdown to display a different Group of items (use the Group parameter).  It can also restrict what items are displayed based on a minimum or maximum value (use Min and Max parameters).</action>
+			<action name="SetGroup">This causes the dropdown to display a different Group of items (use the "Group" parameter).  It can also restrict what items are displayed based on a minimum or maximum value (use "Min" and "Max" parameters).</action>
 
-			<action name="SetItems">This specifies a SQL (use "SQL" parameter) query to use to re-load the contents of the dropdown.  It should have between two and five columns, in this order: label, value, selected (0 or 1, whether the item is selected by default), grp (group name), hidden (0 or 1 to hide the item from the dropdown list but still allow it to be a valid value).</action>
+			<action name="SetItems">This specifies a SQL (use "SQL" parameter) query to use when reloading the contents of the dropdown.  The query should produce between two and five columns the order: label, value, selected (1 for the default selected item, 0 for all others), grp (group name), hidden (1 to hide the item from the dropdown UI even though it's still valid, 0 to show it).  Use the "RowLimit" parameter to specify a maximum number of options that the query should fetch (defaults to 100).</action>
 
-			<action name="SetValue">Changes the child property "value".</action>
+			<action name="SetValue">Changes the child property "Value".</action>
 
 		</actions>
 
@@ -1328,7 +1360,7 @@ myDropDown2 "widget/dropdown"
 
 			<event name="DataChange">This event occurs when the user has modified the data value of the widget (clicked or unclicked it).</event>
 
-			<event name="DataModify">This event occurs when the data is changed (occurs when key press or button changes things).</event>
+			<event name="DataModify">This event occurs when the data is changed (occurs when key press or button changes things).  It provides four parameters. "NewValue" represents the now current value after the modification. "OldValue" representing the previous value.  "FromKeyboard" is 1 if the event is caused by the user typing into the editbox with their keyboard.  "FromOSRC" is 1 if the event is caused by an OSRC modifying the edit box data.</event>
 
 			<event name="EscapePressed">This event occurs when the user presses the escape key.</event>
 
@@ -1358,9 +1390,12 @@ myDropDown2 "widget/dropdown"
 
 			<action name="Enable">The Enable action allows an edit box to be written in, and takes no parameters x from being written in, and takes no parameters.</action>
 
-			<action name="SetFocus">The SetFocus action selects and gives control to an edit box.</action>
 
-			<action name="SetValue">The SetValue action modifies the contents of an editbox, and takes a single parameter, 'Value' (string).</action>
+			<action name="Disable">The Disable action prevents an edit box from being written in. This action takes no parameters.</action>
+
+			<action name="SetFocus">The SetFocus action selects and gives control to an edit box at the specified "X" and "Y" coordinates (even if its not the target?).</action>
+
+			<action name="SetValue">The SetValue action modifies the contents of an editbox, and takes three parameters.  The 'Value' (string) parameter represents the new value of the edit box.  The 'Trigger' (int) parameter is supposed to control whether to trigger the Modified event, however, this event is always triggered regardless of the Trigger value.  The 'Description' parameter is identical to that of the SetValueDescription event.</action>
 
 			<action name="SetValueDescription">This action modifies the "value description" of the editbox, and takes a single parameter, 'Description' (string).</action>
 
@@ -1556,7 +1591,7 @@ mySoundPlayer "widget/execmethod"
 
 			<child type="formelement">
 
-				<childproperty name="fieldname" type="string"><ni />Fieldname (from the dataset) to bind this element to.</childproperty>
+				<childproperty name="fieldname" type="string"><ni />Field name (from the dataset) to bind this element to.</childproperty>
 
 			</child>
 
@@ -1586,9 +1621,9 @@ mySoundPlayer "widget/execmethod"
 
 			<event name="New">This event occurs if and only if there was a mode change and the new mode is the 'New' state (always occurs with both a statusChange event and a ModeChange Event).</event>
 
-			<event name="NoData">This event occurs if and only if there was a mode change and the new mode is the 'NoData' state (always occurs with both a statusChange event and a ModeChange Event.</event>
+			<event name="NoData">This event occurs if and only if there was a mode change and the new mode is the 'NoData' state (always occurs with both a statusChange event and a ModeChange Event.)</event>
 
-			<event name="Query">This event occurs if and only if there was a mode change and the new mode is the 'Query' state (always occurs with both a statusChange event and a ModeChange Event.</event>
+			<event name="Query">This event occurs if and only if there was a mode change and the new mode is the 'Query' state (always occurs with both a statusChange event and a ModeChange Event.)</event>
 
 			<event name="StatusChange">The even occurs when the form changes modes or when a child control changes its data.</event>
 
@@ -1598,23 +1633,23 @@ mySoundPlayer "widget/execmethod"
 
 		<actions>
 
-			<action name="Clear"><ni />Clears the form to a 'no data'state.</action>
+			<action name="Clear"><ni />Clears the form to a 'no data' -state. Specify 1 for the 'force' parameter to clear data even if it is has not been saved.</action>
 
 			<action name="Delete"><ni />Deletes the current object displayed.</action>
 
-			<action name="Discard">Cancels an edit of form contents.</action>
+			<action name="Discard">Cancels an edit of form contents.  Specify 1 for the 'FromKeyboard' or 'FromOSRC' parameters to indicate that the action is caused by a keyboard input or an osrc, respectively (both default to 0).</action>
 
-			<action name="Disable">Prevents interaction with the entire form.</action>
+			<action name="Disable">Prevents interaction with the entire form.  Specify any value other than no for the 'Enabled' parameter to enable it instead.</action>
 
 			<action name="Edit">Allows editing of form's contents.</action>
 
-			<action name="Enable">Allows interaction with the form.</action>
+			<action name="Enable">Allows interaction with the form.   Specify 0 or no for the 'Enabled' parameter to disable it instead.</action>
 
 			<action name="First">Moves the form to the first object in the objectsource.</action>
 
 			<action name="Last">Moves the form to the last object in the objectsource.</action>
 
-			<action name="New"><ni />Allows creation of new form contents.</action>
+			<action name="New"><ni />Allows creation of new form contents.  Specify the 'Multi' parameter to set the MultiEnter field.</action>
 
 			<action name="Next">Moves the form to the next object in the objectsource.</action>
 
@@ -1622,15 +1657,15 @@ mySoundPlayer "widget/execmethod"
 
 			<action name="Query">Allows entering of query criteria.</action>
 
-			<action name="QueryExec">the query and returns data.</action>
+			<action name="QueryExec">Executes the query and returns data.</action>
 
 			<action name="QueryToggle">Either executes a query or allows one to be made depending on the previous state.</action>
 
-			<action name="Save">Saves the form's contents.</action>
+			<action name="Save">Saves the form's contents.  Use the 'completion' parameter to specify a JavaScript function that will run after the action completes. (I don't understand how this works, I just guessed from the JS implementation because I've never seen an app specify this parameter.)</action>
 
-			<action name="SetValue">Modifies a field and puts the form into a new modify or search mode if appropriate.</action>
+			<action name="SetValue">Modifies the specified 'Field' to the specified 'Value', then puts the form into a new modify or search mode, if appropriate.</action>
 
-			<action name="Submit">Attemps to save data, if there is an error it returns false.</action>
+			<action name="Submit">Attempts to save data, if there is an error it returns false.  Specify the 'Target' parameter to set a target page other than the one containing the form widget.  Specify any truthy value for the 'NewPage' parameter to allow launching a new page.</action>
 
 			<action name="test3bconfirm">Debugging tool to test the 3bcomfirm method (only use if you know what this method is).</action>
 
@@ -1661,7 +1696,7 @@ form1 "widget/form"
 
 		<overview>
 
-			<p>Many times with multi-mode forms like those offered by Centrallix, the end-user can become confused as to what the form is currently "doing" (for instance, is a blank form with a blinking cursor in a "new" state or "enter query" state?).  Centrallix helps to address this issue using the form status widget.  A form status widget displays the current mode of operation that a form is in, as well as whether the form is busy processing a query, save, or delete operation.  This clear presentation of the form's mode is intended to clear up any confusion created by a multi-mode form.  This widget is a special-case form element.</p>
+			<p>Many times with multimodal forms like those offered by Centrallix, the end-user can become confused as to what the form is currently "doing" (for instance, is a blank form with a blinking cursor in a "new" state or "enter query" state?).  Centrallix helps to address this issue using the form status widget.  A form status widget displays the current mode of operation that a form is in, as well as whether the form is busy processing a query, save, or delete operation.  This clear presentation of the form's mode is intended to clear up any confusion created by a multimodal form.  This widget is a special-case form element.</p>
 
 		</overview>
 
@@ -1688,6 +1723,8 @@ form1 "widget/form"
 		</children>
 
 		<events>
+
+			<event name="Click">This event occurs when the user clicks the formstatus widget. No parameters are available from this event.</event>
 
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
@@ -1844,7 +1881,7 @@ BigFrameset "widget/frameset"
 
 		<overview>
 
-			<p>The hints widget stores default values and other component modifying properties.</p>
+			<p>The hints widget stores default values and properties that affect data in other widgets, such as input validation data.</p>
 
 		</overview>
 
@@ -3286,7 +3323,13 @@ $Version=2$
 		</properties>
 
 		<events>
-		
+
+			<event name="Scroll">This event occurs any time the user scrolls the scroll pane.  This includes scrolling by clicking the scroll buttons, clicking on the scroll bar, dragging the scroll thumb, turning the scroll wheel, or when the ScrollTo action is used.  This event does not occur when the scroll pane moves because the contained content changed in length, or when the scroll pane is forced to scroll because the available visible area was resized.  This event will never occur if the content within the scroll pane is shorter than the available visible area because then the content cannot be scrolled.  This event provides the :Percent attribute, a number from 0 to 100 (the same as the ScrollTo action above) representing the percentage that the user has now scrolled down the page as of the event occurring.  This event also provides :Change, representing how much the user's scroll location has changed in the same unit as above (although this value will be negative if the user scrolled up).</event>
+
+			<event name="Click">This event occurs when the user moves the mouse pointer while it is over the widget.  The event will repeatedly fire each time the pointer moves.</event>
+
+			<event name="Wheel">This event occurs when the user moves the scroll wheel while it is over the widget (or content inside the widget).  The event will repeatedly fire each time the pointer moves.</event>
+
 			<event name="MouseDown">This event occurs when the user presses the mouse button on the widget.  This differs from the 'Click' event in that the user must actually press and release the mouse button on the widget for a Click event to fire, whereas simply pressing the mouse button down will cause the MouseDown event to fire.</event>
 
 			<event name="MouseMove">This event occurs when the user moves the mouse pointer while it is over the widget.  The event will repeatedly fire each time the pointer moves.</event>
@@ -3640,6 +3683,8 @@ myTabControl "widget/tab"
 				<childproperty name="wrap" type="string">Determines if text can wrap around an obstacle.</childproperty>
 
 			</child>
+			
+			<child type="table-row-detail" />
 
 		</children>
 

--- a/centrallix-os/sys/js/htdrv_editbox.js
+++ b/centrallix-os/sys/js/htdrv_editbox.js
@@ -39,7 +39,8 @@ function eb_actionsetvalue(aparam)
 	this.changed=true;
 	cn_activate(this,"DataModify", {Value:aparam.Value, FromKeyboard:0, FromOSRC:0, OldValue:oldval});
 	}
-    // also check description
+    
+    // Also update the description using aparam.Description.
     this.ifcProbe(ifAction).Invoke('SetValueDescription', aparam);
     }
 

--- a/centrallix-os/sys/js/htdrv_window.js
+++ b/centrallix-os/sys/js/htdrv_window.js
@@ -625,8 +625,7 @@ function wn_togglevisibility(aparam)
 
 function wn_closewin(aparam)
     {
-    aparam.IsVisible = 0;
-    return this.ifcProbe(ifAction).Invoke('SetVisibility',aparam);
+    return this.ifcProbe(ifAction).Invoke('SetVisibility', ({ ...aparam, IsVisible: 0}) );
     }
 
 function wn_openwin(aparam)
@@ -637,12 +636,13 @@ function wn_openwin(aparam)
 	this.point_at = wgtrGetNode(this, this.point_at);
     this.point_offset = aparam.PointOffset;
     this.point_side = aparam.PointSide;
-    aparam.IsVisible = 1;
     if (aparam.X !== undefined && aparam.Y !== undefined)
 	moveToAbsolute(this, aparam.X, aparam.Y);
     else if (aparam.Center && aparam.Center != 'no')
 	moveToAbsolute(this, (pg_width - $(this).width())/2, (pg_height - $(this).height())/2);
-    return this.ifcProbe(ifAction).Invoke('SetVisibility',aparam);
+
+    // Passes aparam.IsModal, aparam.NoClose, and aparam.Cascade on to the SetVisibility action.
+    return this.ifcProbe(ifAction).Invoke('SetVisibility', ({ ...aparam, IsVisible: 1}));
     }
 
 function wn_setvisibility(aparam)

--- a/centrallix/htmlgen/htdrv_editbox.c
+++ b/centrallix/htmlgen/htdrv_editbox.c
@@ -239,9 +239,11 @@ htebInitialize()
 	htrAddParam(drv,"SetValue","Trigger",DATA_T_INTEGER);	/* whether to trigger the Modified event */
 
 	/** Value-modified event **/
-	htrAddEvent(drv,"Modified");
-	htrAddParam(drv,"Modified","NewValue",DATA_T_STRING);
-	htrAddParam(drv,"Modified","OldValue",DATA_T_STRING);
+	htrAddEvent(drv,"DataModify");
+	htrAddParam(drv,"DataModify","NewValue",DATA_T_STRING);
+	htrAddParam(drv,"DataModify","OldValue",DATA_T_STRING);
+	htrAddParam(drv,"DataModify","FromKeyboard",DATA_T_STRING);
+	htrAddParam(drv,"DataModify","FromOSRC",DATA_T_STRING);
 
 	/** Register. **/
 	htrRegisterDriver(drv);

--- a/centrallix/htmlgen/htdrv_editbox.c
+++ b/centrallix/htmlgen/htdrv_editbox.c
@@ -240,7 +240,7 @@ htebInitialize()
 
 	/** Value-modified event **/
 	htrAddEvent(drv,"DataModify");
-	htrAddParam(drv,"DataModify","NewValue",DATA_T_STRING);
+	htrAddParam(drv,"DataModify","Value",DATA_T_STRING);
 	htrAddParam(drv,"DataModify","OldValue",DATA_T_STRING);
 	htrAddParam(drv,"DataModify","FromKeyboard",DATA_T_STRING);
 	htrAddParam(drv,"DataModify","FromOSRC",DATA_T_STRING);

--- a/centrallix/htmlgen/htdrv_fileupload.c
+++ b/centrallix/htmlgen/htdrv_fileupload.c
@@ -123,17 +123,17 @@ htfuInitialize()
 	drv->Render = htfuRender;
 	
 	/** Add actions **/
-	htrAddAction(drv,"Reset");
+	htrAddAction(drv,"Clear");
 	htrAddAction(drv,"Prompt");
 	htrAddAction(drv,"Submit");
 	
-	/** Add event **/
+	/** Add events **/
 	htrAddEvent(drv,"DataChange");
 	htrAddParam(drv,"DataChange","NewValue",DATA_T_STRING);
 	htrAddParam(drv,"DataChange","OldValue",DATA_T_STRING);
-    
-	htrAddEvent(drv,"Success");
-	htrAddParam(drv,"Success","data",DATA_T_ARRAY);
+	htrAddEvent(drv,"UploadComplete");
+	htrAddEvent(drv,"UploadError");
+	htrAddEvent(drv,"Change");
 
 	/** Register. **/
 	htrRegisterDriver(drv);

--- a/centrallix/htmlgen/htdrv_form.c
+++ b/centrallix/htmlgen/htdrv_form.c
@@ -280,6 +280,8 @@ htformInitialize()
 	htrAddAction(drv,"Clear");
 	htrAddAction(drv,"Delete");
 	htrAddAction(drv,"Discard");
+	htrAddAction(drv,"Disable");
+	htrAddAction(drv,"Enable");
 	htrAddAction(drv,"Edit");
 	htrAddAction(drv,"First");
 	htrAddAction(drv,"Last");
@@ -298,7 +300,6 @@ htformInitialize()
 	htrAddEvent(drv,"View");
 	htrAddEvent(drv,"Modify");
 	htrAddEvent(drv,"Query");
-	htrAddEvent(drv,"QueryExec");
 
 	/** Register. **/
 	htrRegisterDriver(drv);

--- a/centrallix/htmlgen/htdrv_osrc.c
+++ b/centrallix/htmlgen/htdrv_osrc.c
@@ -50,69 +50,6 @@ static struct {
 
 enum htosrc_autoquery_types { Unset=-1, Never=0, OnLoad=1, OnFirstReveal=2, OnEachReveal=3  };
 
-#if 00
-/*** AddRule: add a declarative osrc rule to the generated document.
- ***/
-int
-htosrc_internal_AddRule(pHtSession s, pWgtrNode tree, char* treename, pWgtrNode sub_tree)
-    {
-    char ruletype[32];
-    int query_delay;
-    int min_chars;
-    int trailing_wildcard;
-    int leading_wildcard;
-    char fieldname[64];
-    char* ptr;
-    pExpression code;
-
-	/** Get type of rule **/
-	if (wgtrGetPropertyValue(sub_tree, "ruletype", DATA_T_STRING, POD(&ptr)) != 0)
-	    {
-	    mssError(1, "HTOSRC", "ruletype is required for widget/osrc-rule");
-	    return -1;
-	    }
-	strtcpy(ruletype, ptr, sizeof(ruletype));
-
-	/** Handle the rule based on the type **/
-	if (!strcmp(ruletype, "relationship"))
-	    {
-	    }
-	else if (!strcmp(ruletype, "filter"))
-	    {
-	    trailing_wildcard = htrGetBoolean(sub_tree, "trailing_wildcard", 1);
-	    leading_wildcard = htrGetBoolean(sub_tree, "leading_wildcard", 0);
-	    if (wgtrGetPropertyValue(sub_tree, "min_chars", DATA_T_INTEGER, POD(&min_chars)) != 0)
-		min_chars = 3;
-	    if (wgtrGetPropertyValue(sub_tree, "query_delay", DATA_T_INTEGER, POD(&query_delay)) != 0)
-		query_delay = 500;
-	    if (wgtrGetPropertyValue(sub_tree, "fieldname", DATA_T_STRING, POD(&ptr)) == 0)
-		strtcpy(fieldname, ptr, sizeof(fieldname));
-	    else
-		{
-		mssError(1, "HTOSRC", "fieldname is required for widget/osrc-rule of type 'filter'");
-		return -1;
-		}
-
-	    /** Get target **/
-	    if (wgtrGetPropertyType(sub_tree,"value") == DATA_T_CODE)
-		{
-		wgtrGetPropertyValue(sub_tree,"value",DATA_T_CODE,POD(&code));
-		htrAddExpression(s, treename, wgtrGetDName(sub_tree), code);
-		}
-
-	    /** Write the init line **/
-	    htrAddScriptInit_va(s, "    nodes[\"%STR&SYM\"].AddRule('%STR&SYM', {dname:'%STR&SYM', field:'%STR&ESCQ', qd:%INT, mc:%INT, tw:%INT, lw:%INT});\n",
-		    treename, ruletype, wgtrGetDName(sub_tree), fieldname, 
-		    query_delay, min_chars, trailing_wildcard, leading_wildcard);
-	    }
-	else if (!strcmp(ruletype, "keying"))
-	    {
-	    }
-
-    return 0;
-    }
-#endif
-
 /* 
    htosrcRender - generate the HTML code for the page.
    
@@ -131,7 +68,6 @@ htosrcRender(pHtSession s, pWgtrNode tree, int z)
    char *filter;
    char *baseobj;
    pWgtrNode sub_tree;
-//   pObjQuery qy;
    enum htosrc_autoquery_types aq;
    int receive_updates;
    int send_updates;
@@ -272,18 +208,7 @@ htosrcRender(pHtSession s, pWgtrNode tree, int z)
     for (i=0;i<count;i++)
 	{
 	sub_tree = xaGetItem(&(tree->Children), i);
-#if 00
-	if (wgtrGetPropertyValue(sub_tree, "outer_type", DATA_T_STRING, POD(&ptr)) == 0 && !strcmp(ptr, "widget/osrc-rule"))
-	    {
-	    htosrc_internal_AddRule(s, tree, name, sub_tree);
-	    }
-	else
-	    {
-#endif
-	    htrRenderWidget(s, sub_tree, z);
-#if 00
-	    }
-#endif
+	htrRenderWidget(s, sub_tree, z);
 	}
 
     nmSysFree(filter);

--- a/centrallix/htmlgen/htdrv_scrollpane.c
+++ b/centrallix/htmlgen/htdrv_scrollpane.c
@@ -215,13 +215,18 @@ htspaneInitialize()
 	drv->Render = htspaneRender;
 
 	/** Events **/ 
-	htrAddEvent(drv,"Click");
-	htrAddEvent(drv,"MouseUp");
-	htrAddEvent(drv,"MouseDown");
-	htrAddEvent(drv,"MouseOver");
-	htrAddEvent(drv,"MouseOut");
-	htrAddEvent(drv,"MouseMove");
-
+	htrAddEvent(drv, "Click");
+	htrAddEvent(drv, "MouseDown");
+	htrAddEvent(drv, "MouseMove");
+	htrAddEvent(drv, "MouseOut");
+	htrAddEvent(drv, "MouseOver");
+	htrAddEvent(drv, "MouseUp");
+	htrAddEvent(drv, "Scroll");
+	htrAddEvent(drv, "Wheel");
+	
+	/** Actions **/
+	htrAddAction(drv, "ScrollTo");
+	
 	/** Register. **/
 	htrRegisterDriver(drv);
 

--- a/centrallix/htmlgen/htdrv_textarea.c
+++ b/centrallix/htmlgen/htdrv_textarea.c
@@ -212,9 +212,9 @@ httxInitialize()
 	htrAddParam(drv,"SetValue","Trigger",DATA_T_INTEGER);	/* whether to trigger the Modified event */
 
 	/** Value-modified event **/
-	htrAddEvent(drv,"Modified");
-	htrAddParam(drv,"Modified","NewValue",DATA_T_STRING);
-	htrAddParam(drv,"Modified","OldValue",DATA_T_STRING);
+	htrAddEvent(drv,"DataModify");
+	htrAddParam(drv,"DataModify","NewValue",DATA_T_STRING);
+	htrAddParam(drv,"DataModify","OldValue",DATA_T_STRING);
 
 	/** Events **/ 
 	htrAddEvent(drv,"Click");

--- a/centrallix/htmlgen/htdrv_window.c
+++ b/centrallix/htmlgen/htdrv_window.c
@@ -374,7 +374,6 @@ htwinInitialize()
 	htrAddAction(drv,"ToggleVisibility");
 	htrAddAction(drv,"SetVisibility");
 	htrAddParam(drv,"SetVisibility","IsVisible",DATA_T_INTEGER);
-	htrAddParam(drv,"SetVisibility","NoInit",DATA_T_INTEGER);
 
 	/** Add the 'window closed' event **/
 	htrAddEvent(drv,"Close");

--- a/centrallix/wgtr/wgtdrv_osrc.c
+++ b/centrallix/wgtr/wgtdrv_osrc.c
@@ -75,7 +75,6 @@ wgtosrcInitialize()
 
 	wgtrRegisterDriver(name, wgtosrcVerify, wgtosrcNew);
 	wgtrAddType(name, "osrc");
-	wgtrAddType(name, "osrc-rule");
 
 	return 0;
     }


### PR DESCRIPTION
**Changes**:
- Fixed some `htdrv_*.c` files that registered their widget's events/actions incorrectly.
- Improved the DTD spec for `widgets.xml` and updated the entire file to follow the new spec.
- Added many missing widgets, properties, events, and actions.
- Added detailed information about event and action parameters where relevant.
- Reformatted `widgets.xml` to a consistent format.


**Results**:
When running the unfinished doc-report script on `master`, we get a lot of doc issues:

<img width="288" height="214" alt="before doc errors" src="https://github.com/user-attachments/assets/990d439d-020e-452e-9a17-e05cc5096be2" />

========

After this PR, we have significantly fewer issues:

<img width="290" height="212" alt="after doc errors" src="https://github.com/user-attachments/assets/e12dd74d-0a2b-4887-a0af-b9c99d7938a0" />

========

**Note**: The issue count will fall even further after clean up from other PRs like #90 is merged:

<img width="308" height="216" alt="final doc errors" src="https://github.com/user-attachments/assets/b7cbe581-1e7e-4042-8b2b-59ea667d8a90" />

========

**Note 2**: All of these changes were made on the `fix-widget-docs-dev` branch, which is based off of _several_ other branches that aren't merged yet. In order to make this branch, I had to cherry-pick all the commits from that branch onto this branch, which is based off of master. This was a very difficult and technical process, so if you notice any bizarre changes on this branch, please let me know because that might be the cause of the issue.

**Note 3**: When merging, ensure that `6fab4ecaa4fe827adfb9b828bf86e88d4b3c8b2a` is added to the ignore diffs list because it contains the general reformat of `widgets.xml`.

**Note 4**: These issues were detected using the script in PR #101.