### PR TITLE
Fix Insecure Scrubs

### DIFF
--- a/centrallix-lib/include/cxsec.h
+++ b/centrallix-lib/include/cxsec.h
@@ -31,6 +31,8 @@ void cxsecInitialize();
 int cxsecVerifySymbol(const char* sym);
 int cxsecVerifySymbol_n(const char* sym, size_t n);
 
+void cxsecShred(void* data, size_t n_bytes);
+
 #ifndef __GNUC__
 #define __attribute__(a) /* hide function attributes from non-GCC compilers */
 #endif

--- a/centrallix-lib/src/cxsec.c
+++ b/centrallix-lib/src/cxsec.c
@@ -185,9 +185,9 @@ cxsecVerifySymbol_n(const char* sym, size_t n)
 void
 cxsecShred(void* data, size_t n_bytes)
     {
-	memset(data, 0, n_bytes);
-	if (n_bytes > 0)
-	    ((volatile uint8_t*)data)[n_bytes - 1];
+	volatile uint8_t* ptr = (volatile uint8_t*)data;
+	for (size_t i = 0; i < n_bytes; i++)
+	    ptr[i] = 0;
 
     return;
     }

--- a/centrallix-lib/src/cxsec.c
+++ b/centrallix-lib/src/cxsec.c
@@ -186,7 +186,8 @@ void
 cxsecShred(void* data, size_t n_bytes)
     {
 	memset(data, 0, n_bytes);
-	*(volatile uint8_t*)data = *(volatile uint8_t*)data;
-    
+	if (n_bytes > 0)
+	    ((volatile uint8_t*)data)[n_bytes - 1];
+
     return;
     }

--- a/centrallix-lib/src/cxsec.c
+++ b/centrallix-lib/src/cxsec.c
@@ -4,6 +4,9 @@
 #include "cxsec.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
 #include <ctype.h>
 
 /************************************************************************/
@@ -68,6 +71,7 @@ cxsecInitDS(unsigned long* start, unsigned long* end)
     return;
     }
 
+
 void
 cxsecVerifyDS(unsigned long* start, unsigned long* end, char* file, int line)
     {
@@ -86,6 +90,7 @@ cxsecVerifyDS(unsigned long* start, unsigned long* end, char* file, int line)
 	}
     return;
     }
+
 
 void
 cxsecUpdateDS(unsigned long* start, unsigned long* end, char* file, int line)
@@ -137,6 +142,7 @@ cxsecVerifySymbol(const char* sym)
     return 0;
     }
 
+
 int
 cxsecVerifySymbol_n(const char* sym, size_t n)
     {
@@ -163,3 +169,24 @@ cxsecVerifySymbol_n(const char* sym, size_t n)
     return 0;
     }
 
+
+/*** cxssShred() - Erase the given data so that it is no longer readable
+ *** even in raw memory.  This is the same as calling memset_explicit(),
+ *** except that this function works before C23, when memset_explicit()
+ *** was added.
+ *** 
+ *** Also, using this function signifies the intent to scrub possibly
+ *** sensitive data, which makes code more readable.
+ *** 
+ *** @param data A pointer to the data buffer to be erased.
+ *** @param n_bytes The number of bytes allocated to the data buffer.
+ *** 	Causes undefined behavior if incorrect.
+ ***/
+void
+cxsecShred(void* data, size_t n_bytes)
+    {
+	memset(data, 0, n_bytes);
+	*(volatile uint8_t*)data = *(volatile uint8_t*)data;
+    
+    return;
+    }

--- a/centrallix-lib/src/mtsession.c
+++ b/centrallix-lib/src/mtsession.c
@@ -23,6 +23,7 @@
 #include "xstring.h"
 #include "xhash.h"
 #include "strtcpy.h"
+#include "cxsec.h"
 
 /************************************************************************/
 /* Centrallix Application Server System 				*/
@@ -272,7 +273,7 @@ mssAuthenticate(char* username, char* password, int bypass_crypt)
 	if (strchr(username,':'))
 	    {
 	    mssError(1, "MSS", "Attempt to use invalid username '%s'", username);
-	    memset(s, 0, sizeof(MtSession));
+	    cxsecShred(s, sizeof(MtSession));
 	    nmFree(s,sizeof(MtSession));
 	    return -1;
 	    }
@@ -284,7 +285,7 @@ mssAuthenticate(char* username, char* password, int bypass_crypt)
 	    pw = getpwnam(s->UserName);
 	    if (!pw)
 		{
-		memset(s, 0, sizeof(MtSession));
+		cxsecShred(s, sizeof(MtSession));
 		nmFree(s,sizeof(MtSession));
 		return -1;
 		}
@@ -309,7 +310,7 @@ mssAuthenticate(char* username, char* password, int bypass_crypt)
 		encrypted_pwd = (char*)crypt(s->Password,pwd);
 		if (!encrypted_pwd || strcmp(encrypted_pwd,pwd))
 		    {
-		    memset(s, 0, sizeof(MtSession));
+		    cxsecShred(s, sizeof(MtSession));
 		    nmFree(s,sizeof(MtSession));
 		    return -1;
 		    }
@@ -322,7 +323,7 @@ mssAuthenticate(char* username, char* password, int bypass_crypt)
 	    if (!altpass_fd)
 		{
 		mssErrorErrno(1, "MSS", "Could not open auth file '%s'", MSS.AuthFile);
-		memset(s, 0, sizeof(MtSession));
+		cxsecShred(s, sizeof(MtSession));
 		nmFree(s,sizeof(MtSession));
 		return -1;
 		}
@@ -335,7 +336,7 @@ mssAuthenticate(char* username, char* password, int bypass_crypt)
 		if (t == MLX_TOK_ERROR)
 		    {
 		    mssError(0, "MSS", "Could not read auth file '%s'", MSS.AuthFile);
-		    memset(s, 0, sizeof(MtSession));
+		    cxsecShred(s, sizeof(MtSession));
 		    nmFree(s,sizeof(MtSession));
 		    mlxCloseSession(altpass_lxs);
 		    fdClose(altpass_fd, 0);
@@ -365,7 +366,7 @@ mssAuthenticate(char* username, char* password, int bypass_crypt)
 		    encrypted_pwd = (char*)crypt(s->Password,pwd);
 		    if (strcmp(encrypted_pwd,pwd))
 			{
-			memset(s, 0, sizeof(MtSession));
+			cxsecShred(s, sizeof(MtSession));
 			nmFree(s,sizeof(MtSession));
 			return -1;
 			}
@@ -373,7 +374,7 @@ mssAuthenticate(char* username, char* password, int bypass_crypt)
 		}
 	    else
 		{
-		memset(s, 0, sizeof(MtSession));
+		cxsecShred(s, sizeof(MtSession));
 		nmFree(s,sizeof(MtSession));
 		return -1;
 		}
@@ -445,7 +446,7 @@ mssEndSession(pMtSession s)
 	xhDeInit(&s->Params);
 	xaDeInit(&(s->ErrList));
 	xaRemoveItem(&(MSS.Sessions),xaFindItem(&(MSS.Sessions),(void*)s));
-	memset(s, 0, sizeof(MtSession));
+	cxsecShred(s, sizeof(MtSession));
 	nmFree(s,sizeof(MtSession));
 
     return 0;
@@ -836,4 +837,3 @@ mssGetParam(char* paramname)
 
     return p->Value;
     }
-

--- a/centrallix-lib/src/xringqueue.c
+++ b/centrallix-lib/src/xringqueue.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>
+#include "cxsec.h"
 #include "xringqueue.h"
 #include "newmalloc.h"
 
@@ -53,7 +54,7 @@ xrqDeInit(pXRingQueue this)
 
 	/** Free the items **/
 	nmSysFree(this->Items);
-	memset(this,0,sizeof(XRingQueue));
+	cxsecShred(this,sizeof(XRingQueue));
 
     return 0;
     }
@@ -81,7 +82,7 @@ xrqEnqueue(pXRingQueue this, void* item)
 		memcpy(ptr+this->nAlloc,ptr,(this->nextIn)*sizeof(void*));
 
 		/** zero out it's old location to be safe **/
-		memset(ptr,0,sizeof(void*)*this->nextIn);
+		cxsecShred(ptr,sizeof(void*)*this->nextIn);
 
 		/** update the location of nextIn **/
 		this->nextIn+=this->nAlloc;
@@ -138,4 +139,3 @@ xrqCount(pXRingQueue this)
     {
     return ((this->nextIn-this->nextOut)+this->nAlloc)%this->nAlloc;
     }
-

--- a/centrallix/cxss/cxss_credentials_mgr.c
+++ b/centrallix/cxss/cxss_credentials_mgr.c
@@ -11,6 +11,7 @@
 #include "cxss/credentials_mgr.h"
 #include "cxss/credentials_db.h"
 #include "cxss/crypto.h"
+#include "cxss/cxss.h"
 #include <assert.h>
 
 /* Database context */
@@ -285,7 +286,7 @@ cxssAddResource(const char *cxss_userid, const char *resource_id, const char *au
     }
 
     /* Erase plaintext random key from memory */
-    memset(rand_key, 0, sizeof(rand_key));
+    cxssShred(rand_key, sizeof(rand_key));
 
     /* Build struct */
     UserResc.CXSS_UserID = cxss_userid;
@@ -442,4 +443,3 @@ cxssDeleteResource(const char *cxss_userid, const char *resource_id)
     }
     return CXSS_MGR_SUCCESS;
 }
-

--- a/centrallix/cxss/cxss_crypto.c
+++ b/centrallix/cxss/cxss_crypto.c
@@ -8,6 +8,7 @@
 #include <openssl/crypto.h>
 #include <openssl/rsa.h>
 #include <openssl/pem.h>
+#include "cxss/cxss.h"
 #include "cxss/crypto.h"
 #include "cxss/credentials_db.h"
 
@@ -498,8 +499,7 @@ void
 cxssDestroyKey(char *key, size_t keylength)
 {
     if (key && keylength >= 0) {
-        memset(key, 0, keylength);
+        cxssShred(key, keylength);
         free(key);
     }
 }
-

--- a/centrallix/cxss/cxss_keystream.c
+++ b/centrallix/cxss/cxss_keystream.c
@@ -201,9 +201,8 @@ cxssKeystreamFree(pCxssKeystreamState kstate)
 
 	if (kstate->Context)
 	    EVP_CIPHER_CTX_free(kstate->Context);
-	memset(kstate, 0, sizeof(CxssKeystreamState));
+	cxssShred(kstate, sizeof(CxssKeystreamState));
 	nmFree(kstate, sizeof(CxssKeystreamState));
 
     return 0;
     }
-

--- a/centrallix/cxss/cxss_utility.c
+++ b/centrallix/cxss/cxss_utility.c
@@ -8,6 +8,7 @@
 #include "cxlib/xarray.h"
 #include "cxlib/xhash.h"
 #include "cxlib/mtlexer.h"
+#include "cxlib/cxsec.h"
 #include "cxss/cxss.h"
 
 /************************************************************************/
@@ -128,16 +129,25 @@ cxssGenerateHexKey(char* hexkey, size_t len)
     }
 
 
-/*** cxssShred - erase the given data so that it is no longer readable
- *** even in raw memory.  At this point, basically the same as memset().
- *** But using this function signifies the intent and makes the code
- *** more readable.
+
+/*** cxssShred() - Erase the given data so that it is no longer readable
+ *** even in raw memory.  This is the same as calling memset_explicit(),
+ *** except that this function works before C23, when memset_explicit()
+ *** was added.
+ *** 
+ *** Also, using this function signifies the intent to scrub possibly
+ *** sensitive data, which makes code more readable.
+ *** 
+ *** @param data A pointer to the data buffer to be erased.
+ *** @param n_bytes The number of bytes allocated to the data buffer.
+ *** 	Causes undefined behavior if incorrect.
  ***/
-int
-cxssShred(unsigned char* data, size_t n_bytes)
+void
+cxssShred(void* data, size_t n_bytes)
     {
-    memset(data, '\0', n_bytes);
-    return 0;
+	cxsecShred(data, n_bytes);
+
+    return;
     }
 
 
@@ -155,4 +165,3 @@ cxssAddEntropy(unsigned char* data, size_t n_bytes, int entropy_bits_estimate)
 	
     return rval;
     }
-

--- a/centrallix/include/cxss/cxss.h
+++ b/centrallix/include/cxss/cxss.h
@@ -129,7 +129,7 @@ int cxssHexify(unsigned char* bindata, size_t bindatalen, char* hexdata, size_t 
 int cxss_i_Hexify(unsigned char* bindata, size_t bindatalen, char* hexdata, size_t hexdatalen);
 int cxssGenerateKey(unsigned char* key, size_t n_bytes);
 int cxssGenerateHexKey(char* hexkey, size_t len);
-int cxssShred(unsigned char* data, size_t n_bytes);
+void cxssShred(void* data, size_t n_bytes);
 int cxssAddEntropy(unsigned char* data, size_t n_bytes, int entropy_bits_estimate);
 
 /*** Context/Authentication/Endorsement stack functions ***/
@@ -170,4 +170,3 @@ int cxssAuthorizeSpec(char* objectspec, int access_type, int log_mode);
 int cxssAuthorize(char* domain, char* type, char* path, char* attr, int access_type, int log_mode);
 
 #endif /* not defined _CXSS_H */
-

--- a/centrallix/include/cxss/policy.h
+++ b/centrallix/include/cxss/policy.h
@@ -1,7 +1,9 @@
 #ifndef _CXSS_POLICY_H
 #define _CXSS_POLICY_H
 
-#include "cxss/cxss.h"
+#include "cxlib/datatypes.h"
+#include "cxlib/xarray.h"
+#include "obj.h"
 
 /************************************************************************/
 /* Centrallix Application Server System 				*/
@@ -89,4 +91,3 @@ typedef struct _CXSSPOL
     CxssPolicy, *pCxssPolicy;
 
 #endif /* defined _CXSS_POLICY_H */
-

--- a/centrallix/netdrivers/net_http_sess.c
+++ b/centrallix/netdrivers/net_http_sess.c
@@ -265,7 +265,7 @@ nht_i_UnlinkSess(pNhtSessionData sess)
 	    xhDeInit(sess->CachedApps);
 	    nmFree(sess->CachedApps, sizeof(XHashTable));
 	    xhnDeInitContext(&(sess->Hctx));
-	    memset(sess, 0, sizeof(NhtSessionData));
+	    cxssShred(sess, sizeof(NhtSessionData));
 	    nmFree(sess, sizeof(NhtSessionData));
 	    }
 
@@ -906,4 +906,3 @@ nht_i_LookupApp(char* akey, pNhtSessionData *sess, pNhtAppGroup *group, pNhtApp 
 
     return -1;
     }
-

--- a/centrallix/osdrivers/objdrv_mysql.c
+++ b/centrallix/osdrivers/objdrv_mysql.c
@@ -15,6 +15,7 @@
 #include "cxlib/strtcpy.h"
 #include "cxlib/qprintf.h"
 #include "cxlib/util.h"
+#include "cxss/cxss.h"
 #include <assert.h>
 #include <mysql.h>
 
@@ -248,7 +249,7 @@ mysd_internal_GetConn(pMysdNode node)
 		    {
 		    /** Got disconnected.  Discard the connection. **/
 		    mysql_close(&conn->Handle);
-		    memset(conn->Password, 0, sizeof(conn->Password));
+		    cxssShred(conn->Password, sizeof(conn->Password));
 		    xaRemoveItem(&node->Conns, i);
 		    nmFree(conn, sizeof(MysdConn));
 		    i--;
@@ -297,7 +298,7 @@ mysd_internal_GetConn(pMysdNode node)
                     }
 		conn = (pMysdConn)xaGetItem(&node->Conns, found);
                 mysql_close(&conn->Handle);
-                memset(conn->Password, 0, sizeof(conn->Password));
+                cxssShred(conn->Password, sizeof(conn->Password));
                 xaRemoveItem(&node->Conns, found);
                 nmFree(conn, sizeof(MysdConn));
                 }


### PR DESCRIPTION
Several locations in centrallix and centrallix-lib scrub credentials using `memset()`, which [may be optimized away](https://en.cppreference.com/c/string/byte/memset#:~:text=memset%20may%20be%20optimized%20away).

This PR implements `cxsecShred()` in centrallix-lib, which does a volatile read after using `memset()` so that it cannot be optimized away (needed because `memset_s()` and `memset_explicit()` are not available). The PR replaces `memset()` calls to shred sensitive data in centrallix-lib with `cxsecShred()`. It also replaces the `memset()` call in `cxssShred()`, and uses that function to shred data in centrallix, replacing `memset()` calls there.

I did a full review of all 500+ `memset()` calls in the codebase and I believe that none of the remaining calls are used to shred sensitive data (other than the one call in `cxsecShred()` described above, obviously). I also audited every line changed to a shred call, and every call shreds data that might contain credentials, so I don't think any of them are unnecessary.

I'm planning to make another PR that adds the autoconf macros required to support other shredding solutions in centrallix-lib, and I'll link that here when it is done.