### PR TITLE
Add m4 Code to Insecure Scrubs Fix

### DIFF
--- a/centrallix-lib/aclocal.m4
+++ b/centrallix-lib/aclocal.m4
@@ -52,6 +52,62 @@ AC_DEFUN(CHECK_BUILTIN_EXPECT,
     ]
 )
 
+dnl check if memset_explicit(), memset_s(), explicit_bzero() are available.
+AC_DEFUN(CHECK_MEMSET,
+    [
+	AC_MSG_CHECKING(if memset_explicit is available)
+	AC_COMPILE_IFELSE(
+	    [AC_LANG_PROGRAM(
+		[#include <string.h>],
+		[
+		    char buf[16];
+		    memset_explicit(buf, 0, sizeof(buf));
+		]
+	    )],
+	    [
+		AC_DEFINE([HAVE_MEMSET_EXPLICIT], [1], [Define if memset_explicit is available])
+		AC_MSG_RESULT([yes])
+	    ],
+	    [AC_MSG_RESULT([no])]
+	)
+	
+	AC_MSG_CHECKING(if memset_s is available)
+	AC_COMPILE_IFELSE(
+	    [AC_LANG_PROGRAM(
+		[
+		    #define __STDC_WANT_LIB_EXT1__ 1
+		    #include <string.h>
+		],
+		[
+		    char buf[16];
+		    memset_s(buf, sizeof(buf), 0, sizeof(buf));
+		]
+	    )],
+	    [
+		AC_DEFINE([HAVE_MEMSET_S], [1], [Define if memset_s is available])
+		AC_MSG_RESULT([yes])
+	    ],
+	    [AC_MSG_RESULT([no])]
+	)
+	
+	AC_MSG_CHECKING(if explicit_bzero is available)
+	    AC_COMPILE_IFELSE(
+		[AC_LANG_PROGRAM(
+		    [#include <string.h>],
+		    [
+			char buf[16];
+			explicit_bzero(buf, sizeof(buf));
+		    ]
+		)],
+		[
+		    AC_DEFINE([HAVE_EXPLICIT_BZERO], [1], [Define if explicit_bzero is available])
+		    AC_MSG_RESULT([yes])
+		],
+		[AC_MSG_RESULT([no])]
+	    )
+    ]
+)
+
 dnl check if gcc allows -fPIC and -pg at the same time
 AC_DEFUN(CHECK_PROFILE,
     [

--- a/centrallix-lib/aclocal.m4
+++ b/centrallix-lib/aclocal.m4
@@ -56,12 +56,17 @@ dnl check if memset_explicit(), memset_s(), explicit_bzero() are available.
 AC_DEFUN(CHECK_MEMSET,
     [
 	AC_MSG_CHECKING(if memset_explicit is available)
-	AC_COMPILE_IFELSE(
+	AC_RUN_IFELSE(
 	    [AC_LANG_PROGRAM(
 		[#include <string.h>],
 		[
-		    char buf[16];
+		    char buf[[16]];
+		    for (size_t i = 0; i < sizeof(buf); i++)
+			buf[[i]] = i;
 		    memset_explicit(buf, 0, sizeof(buf));
+		    for (size_t i = 0; i < sizeof(buf); i++)
+			if (buf[[i]] != 0)
+			    return -1;
 		]
 	    )],
 	    [
@@ -72,15 +77,20 @@ AC_DEFUN(CHECK_MEMSET,
 	)
 	
 	AC_MSG_CHECKING(if memset_s is available)
-	AC_COMPILE_IFELSE(
+	AC_RUN_IFELSE(
 	    [AC_LANG_PROGRAM(
 		[
 		    #define __STDC_WANT_LIB_EXT1__ 1
 		    #include <string.h>
 		],
 		[
-		    char buf[16];
+		    char buf[[16]];
+		    for (size_t i = 0; i < sizeof(buf); i++)
+			buf[[i]] = i;
 		    memset_s(buf, sizeof(buf), 0, sizeof(buf));
+		    for (size_t i = 0; i < sizeof(buf); i++)
+			if (buf[[i]] != 0)
+			    return -1;
 		]
 	    )],
 	    [
@@ -91,20 +101,25 @@ AC_DEFUN(CHECK_MEMSET,
 	)
 	
 	AC_MSG_CHECKING(if explicit_bzero is available)
-	    AC_COMPILE_IFELSE(
-		[AC_LANG_PROGRAM(
-		    [#include <string.h>],
-		    [
-			char buf[16];
-			explicit_bzero(buf, sizeof(buf));
-		    ]
-		)],
+	AC_RUN_IFELSE(
+	    [AC_LANG_PROGRAM(
+		[#include <string.h>],
 		[
-		    AC_DEFINE([HAVE_EXPLICIT_BZERO], [1], [Define if explicit_bzero is available])
-		    AC_MSG_RESULT([yes])
-		],
-		[AC_MSG_RESULT([no])]
-	    )
+		    char buf[[16]];
+		    for (size_t i = 0; i < sizeof(buf); i++)
+			buf[[i]] = i;
+		    explicit_bzero(buf, sizeof(buf));
+		    for (size_t i = 0; i < sizeof(buf); i++)
+			if (buf[[i]] != 0)
+			    return -1;
+		]
+	    )],
+	    [
+		AC_DEFINE([HAVE_EXPLICIT_BZERO], [1], [Define if explicit_bzero is available])
+		AC_MSG_RESULT([yes])
+	    ],
+	    [AC_MSG_RESULT([no])]
+	)
     ]
 )
 

--- a/centrallix-lib/configure
+++ b/centrallix-lib/configure
@@ -4112,22 +4112,33 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if memset_explicit is available" >&5
 $as_echo_n "checking if memset_explicit is available... " >&6; }
-	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+	if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <string.h>
 int
 main ()
 {
 
-		    char buf16;
+		    char buf[16];
+		    for (size_t i = 0; i < sizeof(buf); i++)
+			buf[i] = i;
 		    memset_explicit(buf, 0, sizeof(buf));
+		    for (size_t i = 0; i < sizeof(buf); i++)
+			if (buf[i] != 0)
+			    return -1;
 
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
+if ac_fn_c_try_run "$LINENO"; then :
 
 
 $as_echo "#define HAVE_MEMSET_EXPLICIT 1" >>confdefs.h
@@ -4140,11 +4151,20 @@ else
 $as_echo "no" >&6; }
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
 
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if memset_s is available" >&5
 $as_echo_n "checking if memset_s is available... " >&6; }
-	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+	if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 		    #define __STDC_WANT_LIB_EXT1__ 1
@@ -4154,15 +4174,20 @@ int
 main ()
 {
 
-		    char buf16;
+		    char buf[16];
+		    for (size_t i = 0; i < sizeof(buf); i++)
+			buf[i] = i;
 		    memset_s(buf, sizeof(buf), 0, sizeof(buf));
+		    for (size_t i = 0; i < sizeof(buf); i++)
+			if (buf[i] != 0)
+			    return -1;
 
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
+if ac_fn_c_try_run "$LINENO"; then :
 
 
 $as_echo "#define HAVE_MEMSET_S 1" >>confdefs.h
@@ -4175,31 +4200,45 @@ else
 $as_echo "no" >&6; }
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
 
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if explicit_bzero is available" >&5
 $as_echo_n "checking if explicit_bzero is available... " >&6; }
-	    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+	if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <string.h>
 int
 main ()
 {
 
-			char buf16;
-			explicit_bzero(buf, sizeof(buf));
+		    char buf[16];
+		    for (size_t i = 0; i < sizeof(buf); i++)
+			buf[i] = i;
+		    explicit_bzero(buf, sizeof(buf));
+		    for (size_t i = 0; i < sizeof(buf); i++)
+			if (buf[i] != 0)
+			    return -1;
 
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
+if ac_fn_c_try_run "$LINENO"; then :
 
 
 $as_echo "#define HAVE_EXPLICIT_BZERO 1" >>confdefs.h
 
-		    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
 else
@@ -4207,7 +4246,10 @@ else
 $as_echo "no" >&6; }
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
 
 
 

--- a/centrallix-lib/configure
+++ b/centrallix-lib/configure
@@ -4110,6 +4110,108 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 
 
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if memset_explicit is available" >&5
+$as_echo_n "checking if memset_explicit is available... " >&6; }
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <string.h>
+int
+main ()
+{
+
+		    char buf16;
+		    memset_explicit(buf, 0, sizeof(buf));
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+
+$as_echo "#define HAVE_MEMSET_EXPLICIT 1" >>confdefs.h
+
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if memset_s is available" >&5
+$as_echo_n "checking if memset_s is available... " >&6; }
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+		    #define __STDC_WANT_LIB_EXT1__ 1
+		    #include <string.h>
+
+int
+main ()
+{
+
+		    char buf16;
+		    memset_s(buf, sizeof(buf), 0, sizeof(buf));
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+
+$as_echo "#define HAVE_MEMSET_S 1" >>confdefs.h
+
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if explicit_bzero is available" >&5
+$as_echo_n "checking if explicit_bzero is available... " >&6; }
+	    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <string.h>
+int
+main ()
+{
+
+			char buf16;
+			explicit_bzero(buf, sizeof(buf));
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+
+$as_echo "#define HAVE_EXPLICIT_BZERO 1" >>confdefs.h
+
+		    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+
+
+
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking if -fPIC and -pg can be used at the same time" >&5
 $as_echo_n "checking if -fPIC and -pg can be used at the same time... " >&6; }

--- a/centrallix-lib/configure.ac
+++ b/centrallix-lib/configure.ac
@@ -43,6 +43,9 @@ CHECK_MAKEDEPEND
 dnl Check for __builtin_expect()
 CHECK_BUILTIN_EXPECT
 
+dnl Check for memset_explicit(), memset_s(), and explicit_bzero().
+CHECK_MEMSET
+
 dnl Check if -pg is allowed with -fPIC
 AH_TEMPLATE([USE_PROFILE], [Define for profiling])
 CHECK_PROFILE

--- a/centrallix-lib/include/cxlibconfig-all.h.in
+++ b/centrallix-lib/include/cxlibconfig-all.h.in
@@ -9,6 +9,9 @@
 /* Define to 1 if you have the `endservent' function. */
 #undef HAVE_ENDSERVENT
 
+/* Define if explicit_bzero is available */
+#undef HAVE_EXPLICIT_BZERO
+
 /* Define to 1 if you have the <fcntl.h> header file. */
 #undef HAVE_FCNTL_H
 
@@ -23,6 +26,12 @@
 
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
+
+/* Define if memset_explicit is available */
+#undef HAVE_MEMSET_EXPLICIT
+
+/* Define if memset_s is available */
+#undef HAVE_MEMSET_S
 
 /* Define to 1 if you have the `select' function. */
 #undef HAVE_SELECT

--- a/centrallix-lib/include/cxlibconfig-internal.h.in
+++ b/centrallix-lib/include/cxlibconfig-internal.h.in
@@ -35,3 +35,11 @@
 /* defined to 1 if SIOCOUTQ is available */
 #undef HAVE_SIOCOUTQ
 
+/* defined to 1 if memset_explict() is available */
+#undef HAVE_MEMSET_EXPLICIT
+
+/* defined to 1 if memset_s() is available */
+#undef HAVE_MEMSET_S
+
+/* defined to 1 if explicit_bzero() is available */
+#undef HAVE_EXPLICIT_BZERO

--- a/centrallix-lib/include/cxsec.h
+++ b/centrallix-lib/include/cxsec.h
@@ -31,6 +31,8 @@ void cxsecInitialize();
 int cxsecVerifySymbol(const char* sym);
 int cxsecVerifySymbol_n(const char* sym, size_t n);
 
+void cxsecShred(void* data, size_t n_bytes);
+
 #ifndef __GNUC__
 #define __attribute__(a) /* hide function attributes from non-GCC compilers */
 #endif

--- a/centrallix-lib/src/cxsec.c
+++ b/centrallix-lib/src/cxsec.c
@@ -185,8 +185,29 @@ cxsecVerifySymbol_n(const char* sym, size_t n)
 void
 cxsecShred(void* data, size_t n_bytes)
     {
+#ifdef MEMSET_EXPLICIT
+#define CXSEC_FOUND
+	memset_explicit(data, 0, n_bytes);
+	return;
+#endif
+
+#ifdef MEMSET_S
+#define CXSEC_FOUND
+	memset_s(data, n_bytes, 0, n_bytes);
+	return;
+#endif
+
+#ifdef HAVE_EXPLICIT_BZERO
+#define CXSEC_FOUND
+	explicit_bzero(data, n_bytes);
+	return;
+#endif
+
+#ifndef CXSEC_FOUND
+#undef CXSEC_FOUND
 	memset(data, 0, n_bytes);
 	*(volatile uint8_t*)data = *(volatile uint8_t*)data;
-    
+#endif
+
     return;
     }

--- a/centrallix-lib/src/cxsec.c
+++ b/centrallix-lib/src/cxsec.c
@@ -1,3 +1,4 @@
+#define __STDC_WANT_LIB_EXT1__ 1
 #ifdef HAVE_CONFIG_H
 #include "cxlibconfig-internal.h"
 #endif
@@ -185,13 +186,13 @@ cxsecVerifySymbol_n(const char* sym, size_t n)
 void
 cxsecShred(void* data, size_t n_bytes)
     {
-#ifdef MEMSET_EXPLICIT
+#ifdef HAVE_MEMSET_EXPLICIT
 #define CXSEC_FOUND
 	memset_explicit(data, 0, n_bytes);
 	return;
 #endif
 
-#ifdef MEMSET_S
+#ifdef HAVE_MEMSET_S
 #define CXSEC_FOUND
 	memset_s(data, n_bytes, 0, n_bytes);
 	return;

--- a/centrallix-lib/src/cxsec.c
+++ b/centrallix-lib/src/cxsec.c
@@ -185,9 +185,9 @@ cxsecVerifySymbol_n(const char* sym, size_t n)
 void
 cxsecShred(void* data, size_t n_bytes)
     {
-	memset(data, 0, n_bytes);
-	if (n_bytes > 0)
-	    ((volatile uint8_t*)data)[n_bytes - 1];
+	volatile uint8_t* ptr = (volatile uint8_t*)data;
+	for (size_t i = 0; i < n_bytes; i++)
+	    ptr[i] = 0;
 
     return;
     }

--- a/centrallix-lib/src/cxsec.c
+++ b/centrallix-lib/src/cxsec.c
@@ -186,7 +186,8 @@ void
 cxsecShred(void* data, size_t n_bytes)
     {
 	memset(data, 0, n_bytes);
-	*(volatile uint8_t*)data = *(volatile uint8_t*)data;
-    
+	if (n_bytes > 0)
+	    ((volatile uint8_t*)data)[n_bytes - 1];
+
     return;
     }

--- a/centrallix-lib/src/cxsec.c
+++ b/centrallix-lib/src/cxsec.c
@@ -4,6 +4,9 @@
 #include "cxsec.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
 #include <ctype.h>
 
 /************************************************************************/
@@ -68,6 +71,7 @@ cxsecInitDS(unsigned long* start, unsigned long* end)
     return;
     }
 
+
 void
 cxsecVerifyDS(unsigned long* start, unsigned long* end, char* file, int line)
     {
@@ -86,6 +90,7 @@ cxsecVerifyDS(unsigned long* start, unsigned long* end, char* file, int line)
 	}
     return;
     }
+
 
 void
 cxsecUpdateDS(unsigned long* start, unsigned long* end, char* file, int line)
@@ -137,6 +142,7 @@ cxsecVerifySymbol(const char* sym)
     return 0;
     }
 
+
 int
 cxsecVerifySymbol_n(const char* sym, size_t n)
     {
@@ -163,3 +169,24 @@ cxsecVerifySymbol_n(const char* sym, size_t n)
     return 0;
     }
 
+
+/*** cxssShred() - Erase the given data so that it is no longer readable
+ *** even in raw memory.  This is the same as calling memset_explicit(),
+ *** except that this function works before C23, when memset_explicit()
+ *** was added.
+ *** 
+ *** Also, using this function signifies the intent to scrub possibly
+ *** sensitive data, which makes code more readable.
+ *** 
+ *** @param data A pointer to the data buffer to be erased.
+ *** @param n_bytes The number of bytes allocated to the data buffer.
+ *** 	Causes undefined behavior if incorrect.
+ ***/
+void
+cxsecShred(void* data, size_t n_bytes)
+    {
+	memset(data, 0, n_bytes);
+	*(volatile uint8_t*)data = *(volatile uint8_t*)data;
+    
+    return;
+    }

--- a/centrallix-lib/src/cxsec.c
+++ b/centrallix-lib/src/cxsec.c
@@ -1,4 +1,6 @@
+#ifdef HAVE_MEMSET_S
 #define __STDC_WANT_LIB_EXT1__ 1
+#endif
 #ifdef HAVE_CONFIG_H
 #include "cxlibconfig-internal.h"
 #endif

--- a/centrallix-lib/src/mtsession.c
+++ b/centrallix-lib/src/mtsession.c
@@ -23,6 +23,7 @@
 #include "xstring.h"
 #include "xhash.h"
 #include "strtcpy.h"
+#include "cxsec.h"
 
 /************************************************************************/
 /* Centrallix Application Server System 				*/
@@ -272,7 +273,7 @@ mssAuthenticate(char* username, char* password, int bypass_crypt)
 	if (strchr(username,':'))
 	    {
 	    mssError(1, "MSS", "Attempt to use invalid username '%s'", username);
-	    memset(s, 0, sizeof(MtSession));
+	    cxsecShred(s, sizeof(MtSession));
 	    nmFree(s,sizeof(MtSession));
 	    return -1;
 	    }
@@ -284,7 +285,7 @@ mssAuthenticate(char* username, char* password, int bypass_crypt)
 	    pw = getpwnam(s->UserName);
 	    if (!pw)
 		{
-		memset(s, 0, sizeof(MtSession));
+		cxsecShred(s, sizeof(MtSession));
 		nmFree(s,sizeof(MtSession));
 		return -1;
 		}
@@ -309,7 +310,7 @@ mssAuthenticate(char* username, char* password, int bypass_crypt)
 		encrypted_pwd = (char*)crypt(s->Password,pwd);
 		if (!encrypted_pwd || strcmp(encrypted_pwd,pwd))
 		    {
-		    memset(s, 0, sizeof(MtSession));
+		    cxsecShred(s, sizeof(MtSession));
 		    nmFree(s,sizeof(MtSession));
 		    return -1;
 		    }
@@ -322,7 +323,7 @@ mssAuthenticate(char* username, char* password, int bypass_crypt)
 	    if (!altpass_fd)
 		{
 		mssErrorErrno(1, "MSS", "Could not open auth file '%s'", MSS.AuthFile);
-		memset(s, 0, sizeof(MtSession));
+		cxsecShred(s, sizeof(MtSession));
 		nmFree(s,sizeof(MtSession));
 		return -1;
 		}
@@ -335,7 +336,7 @@ mssAuthenticate(char* username, char* password, int bypass_crypt)
 		if (t == MLX_TOK_ERROR)
 		    {
 		    mssError(0, "MSS", "Could not read auth file '%s'", MSS.AuthFile);
-		    memset(s, 0, sizeof(MtSession));
+		    cxsecShred(s, sizeof(MtSession));
 		    nmFree(s,sizeof(MtSession));
 		    mlxCloseSession(altpass_lxs);
 		    fdClose(altpass_fd, 0);
@@ -365,7 +366,7 @@ mssAuthenticate(char* username, char* password, int bypass_crypt)
 		    encrypted_pwd = (char*)crypt(s->Password,pwd);
 		    if (strcmp(encrypted_pwd,pwd))
 			{
-			memset(s, 0, sizeof(MtSession));
+			cxsecShred(s, sizeof(MtSession));
 			nmFree(s,sizeof(MtSession));
 			return -1;
 			}
@@ -373,7 +374,7 @@ mssAuthenticate(char* username, char* password, int bypass_crypt)
 		}
 	    else
 		{
-		memset(s, 0, sizeof(MtSession));
+		cxsecShred(s, sizeof(MtSession));
 		nmFree(s,sizeof(MtSession));
 		return -1;
 		}
@@ -445,7 +446,7 @@ mssEndSession(pMtSession s)
 	xhDeInit(&s->Params);
 	xaDeInit(&(s->ErrList));
 	xaRemoveItem(&(MSS.Sessions),xaFindItem(&(MSS.Sessions),(void*)s));
-	memset(s, 0, sizeof(MtSession));
+	cxsecShred(s, sizeof(MtSession));
 	nmFree(s,sizeof(MtSession));
 
     return 0;
@@ -836,4 +837,3 @@ mssGetParam(char* paramname)
 
     return p->Value;
     }
-

--- a/centrallix-lib/src/xringqueue.c
+++ b/centrallix-lib/src/xringqueue.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <string.h>
+#include "cxsec.h"
 #include "xringqueue.h"
 #include "newmalloc.h"
 
@@ -53,7 +54,7 @@ xrqDeInit(pXRingQueue this)
 
 	/** Free the items **/
 	nmSysFree(this->Items);
-	memset(this,0,sizeof(XRingQueue));
+	cxsecShred(this,sizeof(XRingQueue));
 
     return 0;
     }
@@ -81,7 +82,7 @@ xrqEnqueue(pXRingQueue this, void* item)
 		memcpy(ptr+this->nAlloc,ptr,(this->nextIn)*sizeof(void*));
 
 		/** zero out it's old location to be safe **/
-		memset(ptr,0,sizeof(void*)*this->nextIn);
+		cxsecShred(ptr,sizeof(void*)*this->nextIn);
 
 		/** update the location of nextIn **/
 		this->nextIn+=this->nAlloc;
@@ -138,4 +139,3 @@ xrqCount(pXRingQueue this)
     {
     return ((this->nextIn-this->nextOut)+this->nAlloc)%this->nAlloc;
     }
-

--- a/centrallix/cxss/cxss_credentials_mgr.c
+++ b/centrallix/cxss/cxss_credentials_mgr.c
@@ -11,6 +11,7 @@
 #include "cxss/credentials_mgr.h"
 #include "cxss/credentials_db.h"
 #include "cxss/crypto.h"
+#include "cxss/cxss.h"
 #include <assert.h>
 
 /* Database context */
@@ -285,7 +286,7 @@ cxssAddResource(const char *cxss_userid, const char *resource_id, const char *au
     }
 
     /* Erase plaintext random key from memory */
-    memset(rand_key, 0, sizeof(rand_key));
+    cxssShred(rand_key, sizeof(rand_key));
 
     /* Build struct */
     UserResc.CXSS_UserID = cxss_userid;
@@ -442,4 +443,3 @@ cxssDeleteResource(const char *cxss_userid, const char *resource_id)
     }
     return CXSS_MGR_SUCCESS;
 }
-

--- a/centrallix/cxss/cxss_crypto.c
+++ b/centrallix/cxss/cxss_crypto.c
@@ -8,6 +8,7 @@
 #include <openssl/crypto.h>
 #include <openssl/rsa.h>
 #include <openssl/pem.h>
+#include "cxss/cxss.h"
 #include "cxss/crypto.h"
 #include "cxss/credentials_db.h"
 
@@ -498,8 +499,7 @@ void
 cxssDestroyKey(char *key, size_t keylength)
 {
     if (key && keylength >= 0) {
-        memset(key, 0, keylength);
+        cxssShred(key, keylength);
         free(key);
     }
 }
-

--- a/centrallix/cxss/cxss_keystream.c
+++ b/centrallix/cxss/cxss_keystream.c
@@ -201,9 +201,8 @@ cxssKeystreamFree(pCxssKeystreamState kstate)
 
 	if (kstate->Context)
 	    EVP_CIPHER_CTX_free(kstate->Context);
-	memset(kstate, 0, sizeof(CxssKeystreamState));
+	cxssShred(kstate, sizeof(CxssKeystreamState));
 	nmFree(kstate, sizeof(CxssKeystreamState));
 
     return 0;
     }
-

--- a/centrallix/cxss/cxss_utility.c
+++ b/centrallix/cxss/cxss_utility.c
@@ -8,6 +8,7 @@
 #include "cxlib/xarray.h"
 #include "cxlib/xhash.h"
 #include "cxlib/mtlexer.h"
+#include "cxlib/cxsec.h"
 #include "cxss/cxss.h"
 
 /************************************************************************/
@@ -128,16 +129,25 @@ cxssGenerateHexKey(char* hexkey, size_t len)
     }
 
 
-/*** cxssShred - erase the given data so that it is no longer readable
- *** even in raw memory.  At this point, basically the same as memset().
- *** But using this function signifies the intent and makes the code
- *** more readable.
+
+/*** cxssShred() - Erase the given data so that it is no longer readable
+ *** even in raw memory.  This is the same as calling memset_explicit(),
+ *** except that this function works before C23, when memset_explicit()
+ *** was added.
+ *** 
+ *** Also, using this function signifies the intent to scrub possibly
+ *** sensitive data, which makes code more readable.
+ *** 
+ *** @param data A pointer to the data buffer to be erased.
+ *** @param n_bytes The number of bytes allocated to the data buffer.
+ *** 	Causes undefined behavior if incorrect.
  ***/
-int
-cxssShred(unsigned char* data, size_t n_bytes)
+void
+cxssShred(void* data, size_t n_bytes)
     {
-    memset(data, '\0', n_bytes);
-    return 0;
+	cxsecShred(data, n_bytes);
+
+    return;
     }
 
 
@@ -155,4 +165,3 @@ cxssAddEntropy(unsigned char* data, size_t n_bytes, int entropy_bits_estimate)
 	
     return rval;
     }
-

--- a/centrallix/include/cxss/cxss.h
+++ b/centrallix/include/cxss/cxss.h
@@ -129,7 +129,7 @@ int cxssHexify(unsigned char* bindata, size_t bindatalen, char* hexdata, size_t 
 int cxss_i_Hexify(unsigned char* bindata, size_t bindatalen, char* hexdata, size_t hexdatalen);
 int cxssGenerateKey(unsigned char* key, size_t n_bytes);
 int cxssGenerateHexKey(char* hexkey, size_t len);
-int cxssShred(unsigned char* data, size_t n_bytes);
+void cxssShred(void* data, size_t n_bytes);
 int cxssAddEntropy(unsigned char* data, size_t n_bytes, int entropy_bits_estimate);
 
 /*** Context/Authentication/Endorsement stack functions ***/
@@ -170,4 +170,3 @@ int cxssAuthorizeSpec(char* objectspec, int access_type, int log_mode);
 int cxssAuthorize(char* domain, char* type, char* path, char* attr, int access_type, int log_mode);
 
 #endif /* not defined _CXSS_H */
-

--- a/centrallix/include/cxss/policy.h
+++ b/centrallix/include/cxss/policy.h
@@ -1,7 +1,9 @@
 #ifndef _CXSS_POLICY_H
 #define _CXSS_POLICY_H
 
-#include "cxss/cxss.h"
+#include "cxlib/datatypes.h"
+#include "cxlib/xarray.h"
+#include "obj.h"
 
 /************************************************************************/
 /* Centrallix Application Server System 				*/
@@ -89,4 +91,3 @@ typedef struct _CXSSPOL
     CxssPolicy, *pCxssPolicy;
 
 #endif /* defined _CXSS_POLICY_H */
-

--- a/centrallix/netdrivers/net_http_sess.c
+++ b/centrallix/netdrivers/net_http_sess.c
@@ -265,7 +265,7 @@ nht_i_UnlinkSess(pNhtSessionData sess)
 	    xhDeInit(sess->CachedApps);
 	    nmFree(sess->CachedApps, sizeof(XHashTable));
 	    xhnDeInitContext(&(sess->Hctx));
-	    memset(sess, 0, sizeof(NhtSessionData));
+	    cxssShred(sess, sizeof(NhtSessionData));
 	    nmFree(sess, sizeof(NhtSessionData));
 	    }
 
@@ -906,4 +906,3 @@ nht_i_LookupApp(char* akey, pNhtSessionData *sess, pNhtAppGroup *group, pNhtApp 
 
     return -1;
     }
-

--- a/centrallix/osdrivers/objdrv_mysql.c
+++ b/centrallix/osdrivers/objdrv_mysql.c
@@ -15,6 +15,7 @@
 #include "cxlib/strtcpy.h"
 #include "cxlib/qprintf.h"
 #include "cxlib/util.h"
+#include "cxss/cxss.h"
 #include <assert.h>
 #include <mysql.h>
 
@@ -248,7 +249,7 @@ mysd_internal_GetConn(pMysdNode node)
 		    {
 		    /** Got disconnected.  Discard the connection. **/
 		    mysql_close(&conn->Handle);
-		    memset(conn->Password, 0, sizeof(conn->Password));
+		    cxssShred(conn->Password, sizeof(conn->Password));
 		    xaRemoveItem(&node->Conns, i);
 		    nmFree(conn, sizeof(MysdConn));
 		    i--;
@@ -297,7 +298,7 @@ mysd_internal_GetConn(pMysdNode node)
                     }
 		conn = (pMysdConn)xaGetItem(&node->Conns, found);
                 mysql_close(&conn->Handle);
-                memset(conn->Password, 0, sizeof(conn->Password));
+                cxssShred(conn->Password, sizeof(conn->Password));
                 xaRemoveItem(&node->Conns, found);
                 nmFree(conn, sizeof(MysdConn));
                 }


### PR DESCRIPTION
Add m4 macros to detect shred functions, which are used in the C code, if available.

Supported shred functions:
- `memset_explicit()`
- `memset_s()`
- `explicit_bzero()`

The code falls back to the original volatile memset only if none of the above functions are available. (On my dev VM, it looks like `explicit_bzero()` is used.)

**This PR is blocked behind #104**, which will need to be merged before this PR can be reviewed.