### PR TITLE
Fix `ORDER BY` Seg Fault

### DIFF
--- a/centrallix/multiquery/multiq_orderby.c
+++ b/centrallix/multiquery/multiq_orderby.c
@@ -269,6 +269,8 @@ mqobAnalyzeAfterGroup(pQueryStatement stmt)
 	    for(i=0;i<order_qs->Children.nItems;i++)
 		{
 		order_item = (pQueryStructure)(order_qs->Children.Items[i]);
+		if (order_item == NULL || order_item->Expr == NULL) continue;
+		
 		if (sep_groupby || (order_item->Expr && order_item->Expr->AggLevel == 1))
 		    {
 		    /** Found one.  Squirrel it away in our order-by list. **/
@@ -277,7 +279,6 @@ mqobAnalyzeAfterGroup(pQueryStatement stmt)
 			mssError(1, "MQOB", "Too many ORDER BY expressions (max %d)", MQ_MAX_ORDERBY);
 			goto error;
 			}
-		    if (order_item->Expr == NULL) continue;
 		    qe->OrderBy[n_orderby++] = exp_internal_CopyTree(order_item->Expr);
 		    }
 		}

--- a/centrallix/multiquery/multiq_orderby.c
+++ b/centrallix/multiquery/multiq_orderby.c
@@ -16,7 +16,7 @@
 /* Centrallix Application Server System 				*/
 /* Centrallix Core       						*/
 /* 									*/
-/* Copyright (C) 1999-2010 LightSys Technology Services, Inc.		*/
+/* Copyright (C) 1999-2026 LightSys Technology Services, Inc.		*/
 /* 									*/
 /* This program is free software; you can redistribute it and/or modify	*/
 /* it under the terms of the GNU General Public License as published by	*/
@@ -277,7 +277,8 @@ mqobAnalyzeAfterGroup(pQueryStatement stmt)
 			mssError(1, "MQOB", "Too many ORDER BY expressions (max %d)", MQ_MAX_ORDERBY);
 			goto error;
 			}
-		    qe->OrderBy[n_orderby++] = exp_internal_CopyTree(order_item->Expr);
+		    pExpression expr = order_item->Expr;
+		    qe->OrderBy[n_orderby++] = (expr != NULL) ? exp_internal_CopyTree(expr) : NULL;
 		    }
 		}
 	    }

--- a/centrallix/multiquery/multiq_orderby.c
+++ b/centrallix/multiquery/multiq_orderby.c
@@ -271,7 +271,7 @@ mqobAnalyzeAfterGroup(pQueryStatement stmt)
 		order_item = (pQueryStructure)(order_qs->Children.Items[i]);
 		if (order_item == NULL || order_item->Expr == NULL) continue;
 		
-		if (sep_groupby || (order_item->Expr && order_item->Expr->AggLevel == 1))
+		if (sep_groupby || order_item->Expr->AggLevel == 1)
 		    {
 		    /** Found one.  Squirrel it away in our order-by list. **/
 		    if (n_orderby >= MQ_MAX_ORDERBY)

--- a/centrallix/multiquery/multiq_orderby.c
+++ b/centrallix/multiquery/multiq_orderby.c
@@ -277,8 +277,8 @@ mqobAnalyzeAfterGroup(pQueryStatement stmt)
 			mssError(1, "MQOB", "Too many ORDER BY expressions (max %d)", MQ_MAX_ORDERBY);
 			goto error;
 			}
-		    pExpression expr = order_item->Expr;
-		    qe->OrderBy[n_orderby++] = (expr != NULL) ? exp_internal_CopyTree(expr) : NULL;
+		    if (order_item->Expr == NULL) continue;
+		    qe->OrderBy[n_orderby++] = exp_internal_CopyTree(order_item->Expr);
 		    }
 		}
 	    }


### PR DESCRIPTION
This PR fixes a segmentation fault caused by some queries that used order by.

Thank you to Greg for quickly tracking down the issue so that I could write this simple fix.