### PR TITLE
Update test_prt.c

### DIFF
--- a/centrallix/test_prt.c
+++ b/centrallix/test_prt.c
@@ -63,7 +63,7 @@ void* my_ptr;
 
 /*** Instantiate the globals from centrallix.h 
  ***/
-CxGlobals_t CxGlobals;
+extern CxGlobals_t CxGlobals;
 
 /*** Test prt globals
  ***/


### PR DESCRIPTION
Linking was giving issues on newer compilers.  Needed to explicitly state that CxGlobals was external.