### PR TITLE
Add AI Files

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+If you attempt to use background agents and they fail (especially if they have their permissions denied by the user), the cursor UI is probably broken and you should stop using background agents for that session, or pause and attempt to ask the user for clarification. Repeated attempts without taking steps to mitigate this will just cause more breakage in the cursor UI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,10 @@ While it may be very useful to read the following generated files, do not edit t
 - Centrallix-lib/Makefile
 - Centrallix/configure(.sh)
 - Centrallix-lib/configure(.sh)
+
+# Terms
+- **Centrallix** - An open-source web application server and data management engine developed by LightSys. It provides data abstraction, structural embedding, and dynamic widget-based HTML generation (DHTML), serving as the platform on which apps like Kardia are built.
+- **Kardia** - A web-based nonprofit ministry management application built on the Centrallix platform. It provides donor tracking, financial management, and ministry operations for Christian mission organizations.
+- **Object System (ObjectSystem)** - Centrallix's high-level filesystem analog: a unified tree of typed objects allowing controlled read and write access to files, database rows, directories, APIs, reports, and more, each accessible through a consistent path-based API (the OSML). ObjectSystem Drivers (OSDs) provide the intelligence to interpret different object types, allowing disparate data sources to appear as a single coherent hierarchy.
+- **Widget** - A UI component in Centrallix's DHTML application layer, either visual (e.g. buttons, edit boxes, tables) or nonvisual (e.g. forms, event connectors). Widgets are defined as objects in the ObjectSystem and rendered to HTML/JavaScript by widget drivers on the server side. (For info on using specific widgets, see `centrallix-sysdoc/widgets.md`)
+For other terminology or to find more detailed info, read `centrallix-sysdoc/Terminology.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,10 @@ When making meaningful changes to a file (more than a few lines), update the cop
 
 ## Generated files
 While it may be very useful to read the following generated files, do not edit them since changes will be overwritten by builds.
-- Centrallix/Makefile
-- Centrallix-lib/Makefile
-- Centrallix/configure(.sh)
-- Centrallix-lib/configure(.sh)
+- centrallix/Makefile
+- centrallix-lib/Makefile
+- centrallix/configure
+- centrallix-lib/configure
 
 ## Searching
 Instead of searching with `grep`, use `rg` (if available). It's faster, but remember that it ignores `.gitignored` files, hidden files, binaries, etc. This project includes symlinks (both to files and directories), so ensure they are traversed when searching (aka. with `rg -L` or alternatives). Many centrallix structure files (e.g. `.app`, `.cmp`, etc.) are treated as binary files by `rg`, add `-a` when searching them. You may need to combine both flags to navigate these challenges, e.g. `rg -La "pattern"`, or fall back to `grep` if you encounter issues.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ While it may be very useful to read the following generated files, do not edit t
 - Centrallix-lib/configure(.sh)
 
 ## Searching
-Instead of searching with `grep`, use `rg` (if available). It's faster, but remember that it ignores `.gitignored` files, hidden files, binaries, etc. This project includes symlinks (both to files and directories), so ensure they are traversed when searching (aka. with `rg -L` or alternatives).
+Instead of searching with `grep`, use `rg` (if available). It's faster, but remember that it ignores `.gitignored` files, hidden files, binaries, etc. This project includes symlinks (both to files and directories), so ensure they are traversed when searching (aka. with `rg -L` or alternatives). Many centrallix structure files (e.g. `.app`, `.cmp`, etc.) are treated as binary files by `rg`, add `-a` when searching them. You may need to combine both flags to navigate these challenges, e.g. `rg -Lra "pattern"`, or fall back to `grep` if you encounter issues.
 
 # Terms
 - **Centrallix** - An open-source web application server and data management engine developed by LightSys. It provides data abstraction, structural embedding, and dynamic widget-based HTML generation (DHTML), serving as the platform on which apps like Kardia are built.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 When editing/writing files, follow the best practices of the language in use. For styling, understand and match the surrounding style when editing a file, but keep in mind that many files are styled badly or incorrectly. If user instructions, coding best practices, or your memory conflict with styles in a file, they take precedence over the file. If styling is unclear, read `centrallix-sysdoc/BeeleyCodingStyle.md` for clarification.
 
 ## Copyright notices
-When editing a file, update the copyright notice at the top of the file to extend to the current year.
+When making meaningful changes to a file (more than a few lines), update the copyright notice at the top of the file to extend to the current year.
 
 ## Generated files
 While it may be very useful to read the following generated files, do not edit them since changes will be overwritten by builds.
@@ -14,7 +14,7 @@ While it may be very useful to read the following generated files, do not edit t
 - Centrallix-lib/configure(.sh)
 
 ## Searching
-Instead of searching with `grep`, use `rg` (if available). It's faster, but remember that it ignores `.gitignored` files, hidden files, binaries, etc. This project includes symlinks (both to files and directories), so ensure they are traversed when searching (aka. with `rg -L` or alternatives). Many centrallix structure files (e.g. `.app`, `.cmp`, etc.) are treated as binary files by `rg`, add `-a` when searching them. You may need to combine both flags to navigate these challenges, e.g. `rg -Lra "pattern"` (flag order matters), or fall back to `grep` if you encounter issues.
+Instead of searching with `grep`, use `rg` (if available). It's faster, but remember that it ignores `.gitignored` files, hidden files, binaries, etc. This project includes symlinks (both to files and directories), so ensure they are traversed when searching (aka. with `rg -L` or alternatives). Many centrallix structure files (e.g. `.app`, `.cmp`, etc.) are treated as binary files by `rg`, add `-a` when searching them. You may need to combine both flags to navigate these challenges, e.g. `rg -La "pattern"`, or fall back to `grep` if you encounter issues.
 
 
 # Terms

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ For other terminology or to find more detailed info, read `centrallix-sysdoc/Ter
 
 ## Key patterns
 
+Widget names must be unique.
+
 **Data flow**:
 - User interaction → event → `widget/connector` → action on any widget.
 - Form or OSRC updated by action → HTTP to OSML → OSRC replica updated → form or table re-renders.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Editing
+# Editing Files
 
 ## Styling
 Understand and match the surrounding style when editing a file. If that style is unclear, read `centrallix-sysdoc/BeeleyCodingStyle.md` for clarification.
@@ -17,5 +17,25 @@ While it may be very useful to read the following generated files, do not edit t
 - **Centrallix** - An open-source web application server and data management engine developed by LightSys. It provides data abstraction, structural embedding, and dynamic widget-based HTML generation (DHTML), serving as the platform on which apps like Kardia are built.
 - **Kardia** - A web-based nonprofit ministry management application built on the Centrallix platform. It provides donor tracking, financial management, and ministry operations for Christian mission organizations.
 - **Object System (ObjectSystem)** - Centrallix's high-level filesystem analog: a unified tree of typed objects allowing controlled read and write access to files, database rows, directories, APIs, reports, and more, each accessible through a consistent path-based API (the OSML). ObjectSystem Drivers (OSDs) provide the intelligence to interpret different object types, allowing disparate data sources to appear as a single coherent hierarchy.
-- **Widget** - A UI component in Centrallix's DHTML application layer, either visual (e.g. buttons, edit boxes, tables) or nonvisual (e.g. forms, event connectors). Widgets are defined as objects in the ObjectSystem and rendered to HTML/JavaScript by widget drivers on the server side. (For info on using specific widgets, see `centrallix-sysdoc/widgets.md`)
+- **Widget** - A UI component in Centrallix's DHTML application layer, either visual (e.g. buttons, edit boxes, tables) or nonvisual (e.g. forms, event connectors). Widgets are defined as objects in the ObjectSystem and rendered to HTML/JavaScript by widget drivers on the server side.
 For other terminology or to find more detailed info, read `centrallix-sysdoc/Terminology.md`.
+
+# Building Apps
+
+## Where to look
+- **Widget properties, children, events, actions**: `centrallix-doc/Widgets/widgets.xml` covers all widgets.
+- **Structure file syntax** (.app, .cmp, and others): `centrallix-doc/StructureFile.txt`.
+- **Forms** (form modes, element callbacks): `centrallix-sysdoc/HTFormsInterface.md`.
+- **Widget tree / Wgtr module** (server-side tree building, verification, component loading): `centrallix-sysdoc/WidgetTree.md`.
+- **Practical examples**: `centrallix-os/samples/*.app`.
+
+## Key patterns
+**Data flow**:
+- User interaction → event → `widget/connector` → action on any widget.
+- Form or OSRC updated by action → HTTP to OSML → OSRC replica updated → form or table re-renders.
+
+**Expressions in structure files**: Add `$Version=2$` at the top of a `.app` or `.cmp` file to enable `runclient()` expressions in connector parameters and widget properties. Without it, attribute values are static only.
+
+**Master-slave OSRC relationships** — use `widget/rule` with `ruletype=osrc_relationship` (documented under `widget/osrc` children and `widget/rule` in `centrallix-doc/Widgets/widgets.xml`), not the deprecated `Sync`/`DoubleSync` OSRC actions.
+
+**Three independent focus types**: Keyboard, mouse, and data focus are separate. The `widget/page` properties `kbdfocus1/2`, `mousefocus1/2`, `datafocus1/2` style each independently.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,11 @@ Instead of searching with `grep`, use `rg` (if available). It's faster, but reme
 
 - **Centrallix** - An open-source web application server and data management engine developed by LightSys. It provides data abstraction, structural embedding, and dynamic widget-based HTML generation (DHTML), serving as the platform on which apps like Kardia are built.
 
-- **Kardia** - A web-based nonprofit ministry management application built on the Centrallix platform. It provides donor tracking, financial management, and ministry operations for Christian mission organizations.
+- **Kardia** - A web-based system built on the Centrallix platform.
 
-- **Object System (ObjectSystem)** - Centrallix's high-level filesystem analog: a unified tree of typed objects allowing controlled read and write access to files, database rows, directories, APIs, reports, and more, each accessible through a consistent path-based API (the OSML). ObjectSystem Drivers (OSDs) provide the intelligence to interpret different object types, allowing disparate data sources to appear as a single coherent hierarchy.
+- **Object System (ObjectSystem)** - Centrallix's high-level filesystem analog: a tree of typed objects that allows read/write access to files, database rows, APIs, reports, etc. through a consistent path-based API (the OSML). ObjectSystem Drivers (OSDs) provide the interface to handle these diverse data sources in a single, coherent hierarchy.
 
-- **Widget** - A UI component in Centrallix's DHTML application layer, either visual (e.g. buttons, tables) or nonvisual (e.g. forms, connectors). Widgets are defined as objects in the ObjectSystem and rendered to HTML/JavaScript by server side widget drivers.
+- **Widget** - A UI component in Centrallix DHTML, either visual (e.g. buttons, tables) or nonvisual (e.g. forms, connectors), defined as objects in the ObjectSystem and rendered to HTML/JavaScript by widget drivers.
 
 For other terminology or to find more detailed info, read `centrallix-sysdoc/Terminology.md`.
 
@@ -45,4 +45,4 @@ For other terminology or to find more detailed info, read `centrallix-sysdoc/Ter
 - User interaction → event → `widget/connector` → action on any widget.
 - Form or OSRC updated by action → HTTP to OSML → OSRC replica updated → form or table re-renders.
 
-**Expressions in structure files**: Add `$Version=2$` at the top of a `.app` or `.cmp` file to enable `runclient()` expressions in connector parameters and widget properties. Without it, attribute values are static only.
+**Expressions in structure files**: Always add `$Version=2$` at the top of a `.app` or `.cmp` files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ For other terminology or to find more detailed info, read `centrallix-sysdoc/Ter
 # Building Apps
 
 ## Where to look
-- **Widget properties, children, events, actions**: `centrallix-doc/Widgets/widgets.xml` covers all widgets.
+- **Widget properties, children, events, actions**: `centrallix-doc/Widgets/widgets.xml` covers all widgets. `report.xml` in that dir covers report widgets.
 - **Structure file syntax** (.app, .cmp, and others): `centrallix-doc/StructureFile.txt`.
 - **Forms** (form modes, element callbacks): `centrallix-sysdoc/HTFormsInterface.md`.
 - **Widget tree / Wgtr module** (server-side tree building, verification, component loading): `centrallix-sysdoc/WidgetTree.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+## Generated files
+While it may be very useful to read the following generated files, do not edit them since changes will be overwritten by builds.
+- Centrallix/Makefile
+- Centrallix-lib/Makefile
+- Centrallix/configure(.sh)
+- Centrallix-lib/configure(.sh)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,8 @@ While it may be very useful to read the following generated files, do not edit t
 - Centrallix/configure(.sh)
 - Centrallix-lib/configure(.sh)
 
-## Symlinks
-This project includes symlinks (both to files and directories), so ensure they are traversed when searching.
+## Searching
+Instead of searching with `grep`, use `rg` (if available). It's faster, but remember that it ignores `.gitignored` files, hidden files, binaries, etc. This project includes symlinks (both to files and directories), so ensure they are traversed when searching (aka. with `rg -L` or alternatives).
 
 # Terms
 - **Centrallix** - An open-source web application server and data management engine developed by LightSys. It provides data abstraction, structural embedding, and dynamic widget-based HTML generation (DHTML), serving as the platform on which apps like Kardia are built.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Editing Files
 
 ## Styling
-Understand and match the surrounding style when editing a file. If that style is unclear, read `centrallix-sysdoc/BeeleyCodingStyle.md` for clarification.
+When editing/writing files, follow the best practices of the language in use. For styling, understand and match the surrounding style when editing a file, but keep in mind that many files are styled badly or incorrectly. If user instructions, coding best practices, or your memory conflict with styles in a file, they take precedence over the file. If styling is unclear, read `centrallix-sysdoc/BeeleyCodingStyle.md` for clarification.
 
 ## Copyright notices
 When editing a file, update the copyright notice at the top of the file to extend to the current year.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@ While it may be very useful to read the following generated files, do not edit t
 - Centrallix/configure(.sh)
 - Centrallix-lib/configure(.sh)
 
+## Symlinks
+This project includes symlinks (both to files and directories), so ensure they are traversed when searching.
+
 # Terms
 - **Centrallix** - An open-source web application server and data management engine developed by LightSys. It provides data abstraction, structural embedding, and dynamic widget-based HTML generation (DHTML), serving as the platform on which apps like Kardia are built.
 - **Kardia** - A web-based nonprofit ministry management application built on the Centrallix platform. It provides donor tracking, financial management, and ministry operations for Christian mission organizations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ While it may be very useful to read the following generated files, do not edit t
 - Centrallix-lib/configure(.sh)
 
 ## Searching
-Instead of searching with `grep`, use `rg` (if available). It's faster, but remember that it ignores `.gitignored` files, hidden files, binaries, etc. This project includes symlinks (both to files and directories), so ensure they are traversed when searching (aka. with `rg -L` or alternatives). Many centrallix structure files (e.g. `.app`, `.cmp`, etc.) are treated as binary files by `rg`, add `-a` when searching them. You may need to combine both flags to navigate these challenges, e.g. `rg -Lra "pattern"`, or fall back to `grep` if you encounter issues.
+Instead of searching with `grep`, use `rg` (if available). It's faster, but remember that it ignores `.gitignored` files, hidden files, binaries, etc. This project includes symlinks (both to files and directories), so ensure they are traversed when searching (aka. with `rg -L` or alternatives). Many centrallix structure files (e.g. `.app`, `.cmp`, etc.) are treated as binary files by `rg`, add `-a` when searching them. You may need to combine both flags to navigate these challenges, e.g. `rg -Lra "pattern"` (flag order matters), or fall back to `grep` if you encounter issues.
 
 # Terms
 - **Centrallix** - An open-source web application server and data management engine developed by LightSys. It provides data abstraction, structural embedding, and dynamic widget-based HTML generation (DHTML), serving as the platform on which apps like Kardia are built.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,11 @@
+# Editing
+
+## Styling
+Understand and match the surrounding style when editing a file. If that style is unclear, read `centrallix-sysdoc/BeeleyCodingStyle.md` for clarification.
+
+## Copyright notices
+When editing a file, update the copyright notice at the top of the file to extend to the current year.
+
 ## Generated files
 While it may be very useful to read the following generated files, do not edit them since changes will be overwritten by builds.
 - Centrallix/Makefile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,19 @@ While it may be very useful to read the following generated files, do not edit t
 ## Searching
 Instead of searching with `grep`, use `rg` (if available). It's faster, but remember that it ignores `.gitignored` files, hidden files, binaries, etc. This project includes symlinks (both to files and directories), so ensure they are traversed when searching (aka. with `rg -L` or alternatives). Many centrallix structure files (e.g. `.app`, `.cmp`, etc.) are treated as binary files by `rg`, add `-a` when searching them. You may need to combine both flags to navigate these challenges, e.g. `rg -Lra "pattern"` (flag order matters), or fall back to `grep` if you encounter issues.
 
+
 # Terms
+
 - **Centrallix** - An open-source web application server and data management engine developed by LightSys. It provides data abstraction, structural embedding, and dynamic widget-based HTML generation (DHTML), serving as the platform on which apps like Kardia are built.
+
 - **Kardia** - A web-based nonprofit ministry management application built on the Centrallix platform. It provides donor tracking, financial management, and ministry operations for Christian mission organizations.
+
 - **Object System (ObjectSystem)** - Centrallix's high-level filesystem analog: a unified tree of typed objects allowing controlled read and write access to files, database rows, directories, APIs, reports, and more, each accessible through a consistent path-based API (the OSML). ObjectSystem Drivers (OSDs) provide the intelligence to interpret different object types, allowing disparate data sources to appear as a single coherent hierarchy.
-- **Widget** - A UI component in Centrallix's DHTML application layer, either visual (e.g. buttons, edit boxes, tables) or nonvisual (e.g. forms, event connectors). Widgets are defined as objects in the ObjectSystem and rendered to HTML/JavaScript by widget drivers on the server side.
+
+- **Widget** - A UI component in Centrallix's DHTML application layer, either visual (e.g. buttons, tables) or nonvisual (e.g. forms, connectors). Widgets are defined as objects in the ObjectSystem and rendered to HTML/JavaScript by server side widget drivers.
+
 For other terminology or to find more detailed info, read `centrallix-sysdoc/Terminology.md`.
+
 
 # Building Apps
 
@@ -33,12 +40,9 @@ For other terminology or to find more detailed info, read `centrallix-sysdoc/Ter
 - **Practical examples**: `centrallix-os/samples/*.app`.
 
 ## Key patterns
+
 **Data flow**:
 - User interaction → event → `widget/connector` → action on any widget.
 - Form or OSRC updated by action → HTTP to OSML → OSRC replica updated → form or table re-renders.
 
 **Expressions in structure files**: Add `$Version=2$` at the top of a `.app` or `.cmp` file to enable `runclient()` expressions in connector parameters and widget properties. Without it, attribute values are static only.
-
-**Master-slave OSRC relationships** — use `widget/rule` with `ruletype=osrc_relationship` (documented under `widget/osrc` children and `widget/rule` in `centrallix-doc/Widgets/widgets.xml`), not the deprecated `Sync`/`DoubleSync` OSRC actions.
-
-**Three independent focus types**: Keyboard, mouse, and data focus are separate. The `widget/page` properties `kbdfocus1/2`, `mousefocus1/2`, `datafocus1/2` style each independently.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Add the following files that are useful to provide context for AI agents.

Files added:
- `AGENTS.md`: General standard for providing context to most types of agents.
- `CLAUDE.md`: A symlink to `AGENTS.md`, because Claude uses its own standard instead of `AGENTS.md`.
- `.cursorrules`: A file of rules to give to the Cursor agent specifically. Currently, this is just used to patch over some Cursor UI bugs.

**Note**: These files should be minimal since they're included _every_ time you start a new thread with an agent. Thus, we need to avoid including TONS of context that agents won't need in most cases, or that they can easily find out on their own.