### PR TITLE
Fix `ORDER BY` Seg Fault (again...)

### DIFF
--- a/centrallix/multiquery/multiq_orderby.c
+++ b/centrallix/multiquery/multiq_orderby.c
@@ -117,7 +117,8 @@ mqobAnalyzeBeforeGroup(pQueryStatement stmt)
 		for(i=0;i<qs->Children.nItems;i++)
 		    {
 		    item = (pQueryStructure)(qs->Children.Items[i]);
-		    if (item->Expr && item->Expr->AggLevel == 0)
+		    if (item == NULL || item->Expr == NULL) continue;
+		    if (item->Expr->AggLevel == 0)
 			{
 			mask = item->Expr->ObjCoverageMask;
 			total_mask |= mask;
@@ -144,7 +145,8 @@ mqobAnalyzeBeforeGroup(pQueryStatement stmt)
 		     ** 2d.  Order item not on the primary side of a join
 		     **/
 		    item = (pQueryStructure)(qs->Children.Items[i]);
-		    if (item->Expr && item->Expr->AggLevel == 0)
+		    if (item == NULL || item->Expr == NULL) continue;
+		    if (item->Expr->AggLevel == 0)
 			{
 			mask = item->Expr->ObjCoverageMask;
 			for(n_sources = 0; mask; mask >>= 1)

--- a/centrallix/multiquery/multiq_orderby.c
+++ b/centrallix/multiquery/multiq_orderby.c
@@ -256,6 +256,8 @@ mqobAnalyzeAfterGroup(pQueryStatement stmt)
 			{
 			order_item = (pQueryStructure)(order_qs->Children.Items[i]);
 			group_item = (pQueryStructure)(group_qs->Children.Items[i]);
+			if (order_item == NULL || order_item->Expr == NULL) continue;
+			if (group_item == NULL || group_item->Expr == NULL) continue;
 			if (!expCompareExpressions(order_item->Expr, group_item->Expr))
 			    {
 			    sep_groupby = 1;

--- a/centrallix/multiquery/multiq_orderby.c
+++ b/centrallix/multiquery/multiq_orderby.c
@@ -258,9 +258,9 @@ mqobAnalyzeAfterGroup(pQueryStatement stmt)
 			{
 			order_item = (pQueryStructure)(order_qs->Children.Items[i]);
 			group_item = (pQueryStructure)(group_qs->Children.Items[i]);
-			if (order_item == NULL || order_item->Expr == NULL) continue;
-			if (group_item == NULL || group_item->Expr == NULL) continue;
-			if (!expCompareExpressions(order_item->Expr, group_item->Expr))
+			if (order_item == NULL || order_item->Expr == NULL ||
+			    group_item == NULL || group_item->Expr == NULL ||
+			    !expCompareExpressions(order_item->Expr, group_item->Expr))
 			    {
 			    sep_groupby = 1;
 			    break;

--- a/centrallix/multiquery/multiq_orderby.c
+++ b/centrallix/multiquery/multiq_orderby.c
@@ -233,7 +233,7 @@ mqobAnalyzeBeforeGroup(pQueryStatement stmt)
 int
 mqobAnalyzeAfterGroup(pQueryStatement stmt)
     {
-    pQueryStructure order_qs, group_qs, order_item, group_item;
+    pQueryStructure order_qs, group_qs;
     pQueryElement qe = NULL, child;
     int i, n_orderby = 0;
     int sep_groupby = 0;
@@ -256,13 +256,15 @@ mqobAnalyzeAfterGroup(pQueryStatement stmt)
 		    {
 		    for(i=0; i<order_qs->Children.nItems; i++)
 			{
-			pExpression order_expr, group_expr;
-			order_item = (pQueryStructure)(order_qs->Children.Items[i]);
-			group_item = (pQueryStructure)(group_qs->Children.Items[i]);
-			order_expr = (order_item == NULL) ? NULL : order_item->Expr;
-			group_expr = (group_item == NULL) ? NULL : group_item->Expr;
-			if (!order_expr && !group_expr) continue;
-			if (!order_expr || !group_expr || !expCompareExpressions(order_expr, group_expr))
+			pQueryStructure order_item = (pQueryStructure)(order_qs->Children.Items[i]);
+			pQueryStructure group_item = (pQueryStructure)(group_qs->Children.Items[i]);
+			
+			pExpression order_expr = (order_item == NULL) ? NULL : order_item->Expr;
+			pExpression group_expr = (group_item == NULL) ? NULL : group_item->Expr;
+			
+			if (order_expr == NULL && group_expr == NULL) continue;
+			if (order_expr == NULL || group_expr == NULL
+			    || expCompareExpressions(order_expr, group_expr) == 0)
 			    {
 			    sep_groupby = 1;
 			    break;
@@ -274,7 +276,7 @@ mqobAnalyzeAfterGroup(pQueryStatement stmt)
 	    /** Look for ORDER BY items with an Aggregate Level of 1 **/
 	    for(i=0;i<order_qs->Children.nItems;i++)
 		{
-		order_item = (pQueryStructure)(order_qs->Children.Items[i]);
+		pQueryStructure order_item = (pQueryStructure)(order_qs->Children.Items[i]);
 		if (order_item == NULL || order_item->Expr == NULL) continue;
 		
 		if (sep_groupby || order_item->Expr->AggLevel == 1)

--- a/centrallix/multiquery/multiq_orderby.c
+++ b/centrallix/multiquery/multiq_orderby.c
@@ -256,11 +256,13 @@ mqobAnalyzeAfterGroup(pQueryStatement stmt)
 		    {
 		    for(i=0; i<order_qs->Children.nItems; i++)
 			{
+			pExpression order_expr, group_expr;
 			order_item = (pQueryStructure)(order_qs->Children.Items[i]);
 			group_item = (pQueryStructure)(group_qs->Children.Items[i]);
-			if (order_item == NULL || order_item->Expr == NULL ||
-			    group_item == NULL || group_item->Expr == NULL ||
-			    !expCompareExpressions(order_item->Expr, group_item->Expr))
+			order_expr = (order_item == NULL) ? NULL : order_item->Expr;
+			group_expr = (group_item == NULL) ? NULL : group_item->Expr;
+			if (!order_expr && !group_expr) continue;
+			if (!order_expr || !group_expr || !expCompareExpressions(order_expr, group_expr))
 			    {
 			    sep_groupby = 1;
 			    break;


### PR DESCRIPTION
This PR fixes a segmentation fault caused by some queries that used order by.

Sorry if this gives you de ja vu from #107. It turns out there were more seg faults in that area of the code than we thought. I've done a review, and I'm reasonably sure that I've found all of them.