### PR TITLE
Fix Textarea Font Size

### DIFF
--- a/centrallix/htmlgen/htdrv_textarea.c
+++ b/centrallix/htmlgen/htdrv_textarea.c
@@ -169,7 +169,7 @@ httxRender(pHtSession s, pWgtrNode tree, int z)
 	    name, fieldname, form, is_readonly, mode);
 
 	/** HTML body <DIV> element for the base layer. **/
-	htrAddBodyItem_va(s, "<div id=\"tx%POSbase\"><textarea style=\"width:100%%; height:100%%; border:none; outline:none; font-family:inherit;\">\n",id);
+	htrAddBodyItem_va(s, "<div id=\"tx%POSbase\"><textarea style=\"width:100%%; height:100%%; border:none; outline:none; font-family:inherit; font-size:inherit;\">\n",id);
 
 	/** Use CSS border or table for drawing? **/
 	/*if (is_raised)


### PR DESCRIPTION
This quick PR fixes #115, a bug that caused the font size of textarea widgets to be too large.

### Before
<img width="494" height="456" alt="Example Image" src="https://github.com/user-attachments/assets/a621aeb8-1ba0-4608-8c1a-251a4e6a2dc3">

### After
<img width="500" height="473" alt="image" src="https://github.com/user-attachments/assets/fa1f07bf-e17d-4748-a4b0-508ffa1fe743" />