### PR TITLE
Update `cxjs_substring()` to match `exp_fn_substring()`

### DIFF
--- a/centrallix-os/sys/js/ht_render.js
+++ b/centrallix-os/sys/js/ht_render.js
@@ -300,10 +300,19 @@ function cxjs_convert(dt,v)
 function cxjs_substring(s,p,l)
     {
     if (s == null || p == null) return null;
-    if (l == null)
-	return (String(s)).substr(p-1);
-    else
-	return (String (s)).substr(p-1,l);
+    if (typeof s != 'string' || !Number.isInteger(p) || (l != null && !Number.isInteger(l)))
+	return null;
+    
+    let i = p - 1;
+    if (i < 0) i = 0;
+    if (i > s.length) i = s.length;
+
+    const rest = s.slice(i);
+    let len = (l == null) ? rest.length : l;
+    if (len < 0) len = 0;
+    if (len > rest.length) len = rest.length;
+
+    return rest.slice(0, len);
     }
 function cxjs_right(s,l)
     {

--- a/centrallix-os/sys/js/ht_render.js
+++ b/centrallix-os/sys/js/ht_render.js
@@ -299,8 +299,11 @@ function cxjs_convert(dt,v)
     }
 function cxjs_substring(s,p,l)
     {
-    if (s == null || p == null) return null;
-    if (typeof s != 'string' || !Number.isInteger(p) || (l != null && !Number.isInteger(l)))
+    if (s == null || p == null
+	|| (typeof s != 'string' && !(s instanceof String))
+	|| !Number.isInteger(p)
+	|| (l != null && !Number.isInteger(l))
+    )
 	return null;
     
     let i = p - 1;


### PR DESCRIPTION
I caused a bug in the `gift_associations.app` because the client-side version of `substring()` functioned differently from the server side version, as documented in #121. This PR will close #121 by solving this inconsistency issue.