### PR TITLE
Fix Sort Being Lost on `osrc` Refresh

### DIFF
--- a/centrallix-os/sys/js/htdrv_osrc.js
+++ b/centrallix-os/sys/js/htdrv_osrc.js
@@ -102,6 +102,10 @@ function osrc_action_refresh(aparam)
     if (!tr || tr < 1) tr = 1;
     this.doing_refresh = true;
 
+    // Carry the current sort over to the new query
+    if (!this.pendingorderobject && this.orderobject)
+	this.pendingorderobject = this.orderobject;
+
     // Keep track of current object by name
     if (aparam.find_object)
 	{


### PR DESCRIPTION
Refreshing a sorted osrc causes the sort to be lost. This happened for me when I tested refreshing content in a table after the user had clicked a column to sort the content, and the Refresh action dropped the sort. This PR fixes that.