### PR TITLE
Add `allow_sorting` Property

### DIFF
--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -3613,7 +3613,7 @@ myTabControl "widget/tab"
 
 			<property name="allow_selection" type="yes/no">Whether to permit the user to select rows in the table.  Default "yes".</property>
 
-			<property name="allow_sort" type="yes/no">Whether clicking a column header sorts the table by that column.  Acts as the default for all columns; individual columns may override via their own "allow_sort" property.  Default "yes".</property>
+			<property name="allow_sorting" type="yes/no">Whether clicking a column header sorts the table by that column.  Acts as the default for all columns; individual columns may override via their own "allow_sorting" property.  Default "yes".</property>
 
 			<property name="background" type="string">A background image for the table. This "shows through" between table cells.</property>
 
@@ -3723,7 +3723,7 @@ myTabControl "widget/tab"
 
 				<childproperty name="align" type="string">The alignment of the column:  "left" or "right".</childproperty>
 
-				<childproperty name="allow_sort" type="yes/no">Whether clicking this column's header sorts the table by this column.  Defaults to the table's "allow_sort" value (which defaults to "yes").</childproperty>
+				<childproperty name="allow_sorting" type="yes/no">Whether clicking this column's header sorts the table by this column.  Defaults to the table's "allow_sorting" value (which defaults to "yes").</childproperty>
 
 				<childproperty name="caption_fieldname" type="string">It is a pseudonym for the fieldname.</childproperty>
 				

--- a/centrallix-doc/Widgets/widgets.xml
+++ b/centrallix-doc/Widgets/widgets.xml
@@ -3613,6 +3613,8 @@ myTabControl "widget/tab"
 
 			<property name="allow_selection" type="yes/no">Whether to permit the user to select rows in the table.  Default "yes".</property>
 
+			<property name="allow_sort" type="yes/no">Whether clicking a column header sorts the table by that column.  Acts as the default for all columns; individual columns may override via their own "allow_sort" property.  Default "yes".</property>
+
 			<property name="background" type="string">A background image for the table. This "shows through" between table cells.</property>
 
 			<property name="bgcolor" type="string">A color, RGB or named, to be used between table cells and rows.If neither bgcolor nor background are specified, the table is transparent.</property>
@@ -3720,6 +3722,8 @@ myTabControl "widget/tab"
 			<child type="widget/table-column">
 
 				<childproperty name="align" type="string">The alignment of the column:  "left" or "right".</childproperty>
+
+				<childproperty name="allow_sort" type="yes/no">Whether clicking this column's header sorts the table by this column.  Defaults to the table's "allow_sort" value (which defaults to "yes").</childproperty>
 
 				<childproperty name="caption_fieldname" type="string">It is a pseudonym for the fieldname.</childproperty>
 				

--- a/centrallix-os/sys/js/htdrv_table.js
+++ b/centrallix-os/sys/js/htdrv_table.js
@@ -1,4 +1,4 @@
-// Copyright (C) 1998-2014 LightSys Technology Services, Inc.
+// Copyright (C) 1998-2026 LightSys Technology Services, Inc.
 //
 // You may use these files and this library under the terms of the
 // GNU Lesser General Public License, Version 2.1, contained in the

--- a/centrallix-os/sys/js/htdrv_table.js
+++ b/centrallix-os/sys/js/htdrv_table.js
@@ -3087,7 +3087,7 @@ function tbld_mousedown(e)
 		    }
 		}
 	    }
-        if(ly.subkind=='headercell')
+        if(ly.subkind=='headercell' && ly.row.table.cols[ly.colnum].allow_sort)
             {
             var neworder=new Array();
             for(var i in ly.row.table.osrc.orderobject)

--- a/centrallix-os/sys/js/htdrv_table.js
+++ b/centrallix-os/sys/js/htdrv_table.js
@@ -3087,7 +3087,7 @@ function tbld_mousedown(e)
 		    }
 		}
 	    }
-        if(ly.subkind=='headercell' && ly.row.table.cols[ly.colnum].allow_sort)
+        if(ly.subkind=='headercell' && ly.row.table.cols[ly.colnum].allow_sorting)
             {
             var neworder=new Array();
             for(var i in ly.row.table.osrc.orderobject)

--- a/centrallix/htmlgen/htdrv_table.c
+++ b/centrallix/htmlgen/htdrv_table.c
@@ -15,7 +15,7 @@
 /* Centrallix Application Server System 				*/
 /* Centrallix Core       						*/
 /* 									*/
-/* Copyright (C) 1999-2007 LightSys Technology Services, Inc.		*/
+/* Copyright (C) 1999-2026 LightSys Technology Services, Inc.		*/
 /* 									*/
 /* This program is free software; you can redistribute it and/or modify	*/
 /* it under the terms of the GNU General Public License as published by	*/

--- a/centrallix/htmlgen/htdrv_table.c
+++ b/centrallix/htmlgen/htdrv_table.c
@@ -91,6 +91,7 @@ typedef struct
     int item_width;
     int item_height;
     int item_spacing;
+    int allow_sort;
     }
     httbl_col;
 
@@ -144,6 +145,7 @@ typedef struct
     int demand_scrollbar;	/* only show scrollbar when needed */
     int has_header;		/* table has header/title row? */
     int rowcache_size;		/* number of rows the table caches for display */
+    int allow_sort;		/* allow header-click column sort */
     } httbl_struct;
 
 int
@@ -201,7 +203,7 @@ httblRenderDynamic(pHtSession s, pWgtrNode tree, int z, httbl_struct* t)
 	for(colid=0;colid<t->ncols;colid++)
 	    {
 	    col = t->col_infs[colid];
-	    htrAddScriptInit_va(s,"{name:\"%STR&JSSTR\",ns:\"%STR&JSSTR\",fieldname:\"%STR&JSSTR\",sort_fieldname:\"%STR&JSSTR\",title:\"%STR&JSSTR\",width:%INT,type:\"%STR&JSSTR\",group:%POS,align:\"%STR&JSSTR\",wrap:\"%STR&JSSTR\",caption_fieldname:\"%STR&JSSTR\",caption_textcolor:\"%STR&JSSTR\",image_maxwidth:%POS,image_maxheight:%POS,item_separator:\"%STR&JSSTR\",item_type:\"%STR&JSSTR\",item_source:\"%STR&JSSTR\",item_width:%POS,item_height:%POS,item_spacing:%POS},",
+	    htrAddScriptInit_va(s,"{name:\"%STR&JSSTR\",ns:\"%STR&JSSTR\",fieldname:\"%STR&JSSTR\",sort_fieldname:\"%STR&JSSTR\",title:\"%STR&JSSTR\",width:%INT,type:\"%STR&JSSTR\",group:%POS,align:\"%STR&JSSTR\",wrap:\"%STR&JSSTR\",caption_fieldname:\"%STR&JSSTR\",caption_textcolor:\"%STR&JSSTR\",image_maxwidth:%POS,image_maxheight:%POS,item_separator:\"%STR&JSSTR\",item_type:\"%STR&JSSTR\",item_source:\"%STR&JSSTR\",item_width:%POS,item_height:%POS,item_spacing:%POS,allow_sort:%INT},",
 		    col->wname,
 		    col->wnamespace,
 		    col->fieldname,
@@ -221,7 +223,8 @@ httblRenderDynamic(pHtSession s, pWgtrNode tree, int z, httbl_struct* t)
 		    col->item_source,
 		    col->item_width,
 		    col->item_height,
-		    col->item_spacing
+		    col->item_spacing,
+		    col->allow_sort
 		    );
 	    }
 
@@ -380,6 +383,7 @@ httblRender(pHtSession s, pWgtrNode tree, int z)
 	t->hide_scrollbar = htrGetBoolean(tree, "hide_scrollbar", 0);
 	t->demand_scrollbar = htrGetBoolean(tree, "demand_scrollbar", 0);
 	t->has_header = htrGetBoolean(tree, "titlebar", 1);
+	t->allow_sort = htrGetBoolean(tree, "allow_sort", 1);
 
 	/** Which data mode to use? **/
 	if (wgtrGetPropertyValue(tree,"data_mode", DATA_T_STRING, POD(&ptr)) == 0)
@@ -498,6 +502,7 @@ httblRender(pHtSession s, pWgtrNode tree, int z)
 		    strcpy(col->type, "text");
 		if (htrGetBoolean(sub_tree, "group_by", 0) == 1)
 		    strcpy(col->group, "yes");
+		col->allow_sort = htrGetBoolean(sub_tree, "allow_sort", t->allow_sort);
 
 		// ItemList column type properties
 		if (!strcmp(col->type, "itemlist"))

--- a/centrallix/htmlgen/htdrv_table.c
+++ b/centrallix/htmlgen/htdrv_table.c
@@ -91,7 +91,7 @@ typedef struct
     int item_width;
     int item_height;
     int item_spacing;
-    int allow_sort;
+    int allow_sorting;
     }
     httbl_col;
 
@@ -145,7 +145,7 @@ typedef struct
     int demand_scrollbar;	/* only show scrollbar when needed */
     int has_header;		/* table has header/title row? */
     int rowcache_size;		/* number of rows the table caches for display */
-    int allow_sort;		/* allow header-click column sort */
+    int allow_sorting;		/* allow header-click column sort */
     } httbl_struct;
 
 int
@@ -203,7 +203,7 @@ httblRenderDynamic(pHtSession s, pWgtrNode tree, int z, httbl_struct* t)
 	for(colid=0;colid<t->ncols;colid++)
 	    {
 	    col = t->col_infs[colid];
-	    htrAddScriptInit_va(s,"{name:\"%STR&JSSTR\",ns:\"%STR&JSSTR\",fieldname:\"%STR&JSSTR\",sort_fieldname:\"%STR&JSSTR\",title:\"%STR&JSSTR\",width:%INT,type:\"%STR&JSSTR\",group:%POS,align:\"%STR&JSSTR\",wrap:\"%STR&JSSTR\",caption_fieldname:\"%STR&JSSTR\",caption_textcolor:\"%STR&JSSTR\",image_maxwidth:%POS,image_maxheight:%POS,item_separator:\"%STR&JSSTR\",item_type:\"%STR&JSSTR\",item_source:\"%STR&JSSTR\",item_width:%POS,item_height:%POS,item_spacing:%POS,allow_sort:%INT},",
+	    htrAddScriptInit_va(s,"{name:\"%STR&JSSTR\",ns:\"%STR&JSSTR\",fieldname:\"%STR&JSSTR\",sort_fieldname:\"%STR&JSSTR\",title:\"%STR&JSSTR\",width:%INT,type:\"%STR&JSSTR\",group:%POS,align:\"%STR&JSSTR\",wrap:\"%STR&JSSTR\",caption_fieldname:\"%STR&JSSTR\",caption_textcolor:\"%STR&JSSTR\",image_maxwidth:%POS,image_maxheight:%POS,item_separator:\"%STR&JSSTR\",item_type:\"%STR&JSSTR\",item_source:\"%STR&JSSTR\",item_width:%POS,item_height:%POS,item_spacing:%POS,allow_sorting:%INT},",
 		    col->wname,
 		    col->wnamespace,
 		    col->fieldname,
@@ -224,7 +224,7 @@ httblRenderDynamic(pHtSession s, pWgtrNode tree, int z, httbl_struct* t)
 		    col->item_width,
 		    col->item_height,
 		    col->item_spacing,
-		    col->allow_sort
+		    col->allow_sorting
 		    );
 	    }
 
@@ -383,7 +383,7 @@ httblRender(pHtSession s, pWgtrNode tree, int z)
 	t->hide_scrollbar = htrGetBoolean(tree, "hide_scrollbar", 0);
 	t->demand_scrollbar = htrGetBoolean(tree, "demand_scrollbar", 0);
 	t->has_header = htrGetBoolean(tree, "titlebar", 1);
-	t->allow_sort = htrGetBoolean(tree, "allow_sort", 1);
+	t->allow_sorting = htrGetBoolean(tree, "allow_sorting", 1);
 
 	/** Which data mode to use? **/
 	if (wgtrGetPropertyValue(tree,"data_mode", DATA_T_STRING, POD(&ptr)) == 0)
@@ -502,7 +502,7 @@ httblRender(pHtSession s, pWgtrNode tree, int z)
 		    strcpy(col->type, "text");
 		if (htrGetBoolean(sub_tree, "group_by", 0) == 1)
 		    strcpy(col->group, "yes");
-		col->allow_sort = htrGetBoolean(sub_tree, "allow_sort", t->allow_sort);
+		col->allow_sorting = htrGetBoolean(sub_tree, "allow_sorting", t->allow_sorting);
 
 		// ItemList column type properties
 		if (!strcmp(col->type, "itemlist"))


### PR DESCRIPTION
This PR adds the `allow_sorting` property to `table-column` widgets that allow the app designer to disable clicking the header row of a table to sort by that given column. It also adds the `allow_sorting` property to the entire table, where it serves as a default for columns where the property is not specified. This value defaults to `yes`, which gives the current behavior.

This functionality will be very useful for apps where clicking the header row to sort is either not needed, does not make sense, or is just simply very hard to implement correctly.