### PR TITLE
Fix Bugs While Dragging Modals

### DIFF
--- a/centrallix-os/sys/js/htdrv_page.js
+++ b/centrallix-os/sys/js/htdrv_page.js
@@ -2735,8 +2735,6 @@ function pg_dotip_complete()
 // Is the DIV or LAYER "l" restricted due to a modal dialog?
 function pg_checkmodal(l)
     {
-    // Let events through while a window drag is in progress.
-    if (window.wn_current) return false;
     var restricted = pg_modallayer && !pg_isinlayer(pg_modallayer, l) && !(wgtrIsNode(l) && wgtrIsNode(pg_modallayer) && wgtrIsChild(pg_modallayer, l));
     if (restricted && l.kind == 'dt_pn' && ((l.ml && wgtrIsNode(l.ml) && wgtrIsNode(pg_modallayer) && wgtrIsChild(pg_modallayer, l.ml)) || (l.parentElement && l.parentElement.ml && wgtrIsNode(l.parentElement.ml) && wgtrIsNode(pg_modallayer) && wgtrIsChild(pg_modallayer, l.parentElement.ml))))
 	restricted = false;
@@ -2754,7 +2752,8 @@ function pg_mousemove(e)
 	pg_tipinfo.x = e.pageX;
 	pg_tipinfo.y = e.pageY;
 	}
-    if (pg_checkmodal(ly)) return EVENT_HALT | EVENT_PREVENT_DEFAULT_ACTION;
+    // A window drag must keep tracking the cursor when it moves off the modal.
+    if (pg_checkmodal(ly) && !window.wn_current) return EVENT_HALT | EVENT_PREVENT_DEFAULT_ACTION;
     /*if (pg_modallayer)
         {
         if (!pg_isinlayer(pg_modallayer, ly)) return EVENT_HALT | EVENT_PREVENT_DEFAULT_ACTION;
@@ -2882,7 +2881,8 @@ function pg_mouseup(e)
     {
     var ly = e.layer;
     if (ly.mainlayer) ly = ly.mainlayer;
-    if (pg_checkmodal(ly)) return EVENT_HALT | EVENT_PREVENT_DEFAULT_ACTION;
+    // A window drag must be able to terminate when released off the modal.
+    if (pg_checkmodal(ly) && !window.wn_current) return EVENT_HALT | EVENT_PREVENT_DEFAULT_ACTION;
     /*if (pg_modallayer)
         {
         if (!pg_isinlayer(pg_modallayer, ly)) return EVENT_HALT | EVENT_ALLOW_DEFAULT_ACTION;

--- a/centrallix-os/sys/js/htdrv_page.js
+++ b/centrallix-os/sys/js/htdrv_page.js
@@ -2735,6 +2735,8 @@ function pg_dotip_complete()
 // Is the DIV or LAYER "l" restricted due to a modal dialog?
 function pg_checkmodal(l)
     {
+    // Let events through while a window drag is in progress.
+    if (window.wn_current) return false;
     var restricted = pg_modallayer && !pg_isinlayer(pg_modallayer, l) && !(wgtrIsNode(l) && wgtrIsNode(pg_modallayer) && wgtrIsChild(pg_modallayer, l));
     if (restricted && l.kind == 'dt_pn' && ((l.ml && wgtrIsNode(l.ml) && wgtrIsNode(pg_modallayer) && wgtrIsChild(pg_modallayer, l.ml)) || (l.parentElement && l.parentElement.ml && wgtrIsNode(l.parentElement.ml) && wgtrIsNode(pg_modallayer) && wgtrIsChild(pg_modallayer, l.parentElement.ml))))
 	restricted = false;

--- a/centrallix-os/sys/js/htdrv_window.js
+++ b/centrallix-os/sys/js/htdrv_window.js
@@ -749,8 +749,8 @@ function wn_mousedown(e)
         {
         if (e.target.name == 'close')
             pg_set(e.target,'src','/sys/images/02bigclose.gif');
-        else if ((e.mainlayer.has_titlebar && cx__capabilities.Dom0NS && e.pageY < e.mainlayer.pageY + 24) ||
-                (cx__capabilities.Dom1HTML && e.layer.subkind == 'titlebar' ))
+        else if (e.which == 1 && ((e.mainlayer.has_titlebar && cx__capabilities.Dom0NS && e.pageY < e.mainlayer.pageY + 24) ||
+                (cx__capabilities.Dom1HTML && e.layer.subkind == 'titlebar' )))
             {
             wn_current = e.mainlayer;
             wn_msx = e.pageX;


### PR DESCRIPTION
This PR will fix bugs caused by the assumption that modal child widget will never be dragged. Modals with visible titlebars can be dragged, so this PR makes that experience much smoother.