### PR TITLE
Fix Typo

### DIFF
--- a/centrallix-lib/src/cxsec.c
+++ b/centrallix-lib/src/cxsec.c
@@ -173,7 +173,7 @@ cxsecVerifySymbol_n(const char* sym, size_t n)
     }
 
 
-/*** cxssShred() - Erase the given data so that it is no longer readable
+/*** cxsecShred() - Erase the given data so that it is no longer readable
  *** even in raw memory.  This is the same as calling memset_explicit(),
  *** except that this function works before C23, when memset_explicit()
  *** was added.


### PR DESCRIPTION
Fix a minor typo in a function doc comment.